### PR TITLE
feat: add Shift+Enter newline and Cmd+Backspace kill-line shortcuts

### DIFF
--- a/Notchy/TerminalManager.swift
+++ b/Notchy/TerminalManager.swift
@@ -33,6 +33,18 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self = self, self.window?.firstResponder === self else { return event }
 
+            // Shift+Enter → send newline without submitting (for multi-line input)
+            if event.keyCode == 36 && event.modifierFlags.contains(.shift) {
+                self.send(txt: "\n")
+                return nil
+            }
+
+            // Cmd+Backspace → kill line (send Ctrl-U to clear from cursor to start of line)
+            if event.keyCode == 51 && event.modifierFlags.contains(.command) {
+                self.send(txt: "\u{15}")
+                return nil
+            }
+
             let arrowCode: String?
             switch event.keyCode {
             case 126: arrowCode = "A" // Up


### PR DESCRIPTION
## Summary
- **Shift+Return**: sends a literal newline (`\n`) for multi-line input in Claude Code
- **Cmd+Backspace**: sends Ctrl-U to clear the current line (kill-line), matching macOS text editing convention

Both shortcuts are intercepted in the existing `installArrowKeyMonitor()` key monitor in `TerminalManager.swift` before SwiftTerm processes the event.

## Test plan
- [x] Build succeeds (Release configuration)
- [ ] Open Notchy → start a Claude Code session
- [ ] Press Shift+Enter → newline inserted without submitting
- [ ] Press Cmd+Backspace → current line cleared
- [ ] Press Enter alone → submits normally (unchanged)
- [ ] Press Backspace alone → deletes char normally (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)