### PR TITLE
Add option to disable notch hover opening

### DIFF
--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -75,6 +75,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         notchWindow?.isPanelVisible = { [weak self] in
             self?.panel.isVisible ?? false
         }
+        notchWindow?.isHoverEnabled = { [weak self] in
+            self?.settings.hoverToOpenEnabled ?? true
+        }
     }
 
     private func setupHotkey() {

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -16,6 +16,8 @@ class NotchWindow: NSPanel {
     /// Closure to check if the main panel is currently visible.
     /// When the panel is visible, the notch stays in hover-grown size.
     var isPanelVisible: (() -> Bool)?
+    /// Closure to check whether hover-open is currently enabled.
+    var isHoverEnabled: (() -> Bool)?
 
     /// Detected notch dimensions (updated on screen change).
     private var notchWidth: CGFloat = 180
@@ -92,6 +94,7 @@ class NotchWindow: NSPanel {
     // MARK: - Drag destination (treat drag-over like hover)
 
     func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard isHoverEnabled?() ?? true else { return [] }
         onHover?()
         return .generic
     }
@@ -322,6 +325,15 @@ class NotchWindow: NSPanel {
     }
 
     private func checkMouse() {
+        let hoverEnabled = isHoverEnabled?() ?? true
+        if !hoverEnabled {
+            if isHovered {
+                isHovered = false
+                hoverShrink()
+            }
+            return
+        }
+
         let mouseLocation = NSEvent.mouseLocation
 
         // Check the notch area itself

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -32,11 +32,15 @@ class NotchWindow: NSPanel {
 
     /// Whether the mouse is currently hovering over the notch
     private var isHovered = false
+    /// Whether the overlay is temporarily letting clicks pass through.
+    private var isPassThroughActive = false
     /// The pill-shaped background view shown when expanded
     private let pillView = NotchPillView()
 
     /// SwiftUI content overlay shown inside the pill when expanded
     private var pillContentHost: NSHostingView<NotchPillContent>?
+
+    private static let passThroughAlpha: CGFloat = 0.2
 
     init(onHover: @escaping () -> Void) {
         self.onHover = onHover
@@ -325,18 +329,7 @@ class NotchWindow: NSPanel {
     }
 
     private func checkMouse() {
-        let hoverEnabled = isHoverEnabled?() ?? true
-        if !hoverEnabled {
-            if isHovered {
-                isHovered = false
-                hoverShrink()
-            }
-            return
-        }
-
         let mouseLocation = NSEvent.mouseLocation
-
-        // Check the notch area itself
         guard let screen = NSScreen.builtIn else { return }
         let screenFrame = screen.frame
         let effectiveWidth = isExpanded ? notchWidth + 80 : notchWidth
@@ -346,8 +339,20 @@ class NotchWindow: NSPanel {
             width: effectiveWidth,
             height: notchHeight + 1  // +1 so the top screen edge (maxY) is inside the rect
         )
-
         let mouseInNotch = notchRect.contains(mouseLocation)
+
+        let hoverEnabled = isHoverEnabled?() ?? true
+        if !hoverEnabled {
+            updatePassThrough(active: mouseInNotch)
+            if isHovered {
+                isHovered = false
+                hoverShrink()
+            }
+            return
+        }
+
+        updatePassThrough(active: false)
+
         let mouseInAdditional = additionalHoverRects.contains { $0().contains(mouseLocation) }
 
         if mouseInNotch || mouseInAdditional {
@@ -374,6 +379,19 @@ class NotchWindow: NSPanel {
         guard isHovered else { return }
         isHovered = false
         hoverShrink()
+    }
+
+    private func updatePassThrough(active: Bool) {
+        guard active != isPassThroughActive else { return }
+        isPassThroughActive = active
+        ignoresMouseEvents = active
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.12
+            let targetAlpha: CGFloat = active ? Self.passThroughAlpha : 1
+            pillView.animator().alphaValue = targetAlpha
+            pillContentHost?.animator().alphaValue = targetAlpha
+        }
     }
 
     // MARK: - Hover grow / shrink

--- a/Notchy/PanelContentView.swift
+++ b/Notchy/PanelContentView.swift
@@ -35,6 +35,7 @@ struct PanelContentView: View {
     var onClose: () -> Void
     var onToggleExpand: (() -> Void)?
     @State private var showRestoreConfirmation = false
+    @Bindable private var settings = SettingsManager.shared
 
     private var foregroundOpacity: Double {
         sessionStore.isWindowFocused ? 1.0 : 0.6
@@ -187,12 +188,16 @@ struct PanelContentView: View {
                 // Terminal area
                 if let session = sessionStore.activeSession {
                     if session.hasStarted {
-                        TerminalSessionView(
-                            sessionId: session.id,
-                            workingDirectory: session.workingDirectory,
-                            launchClaude: session.projectPath != nil,
-                            generation: session.generation
-                        )
+                        if settings.terminalBackend == .embedded {
+                            TerminalSessionView(
+                                sessionId: session.id,
+                                workingDirectory: session.workingDirectory,
+                                launchClaude: session.projectPath != nil,
+                                generation: session.generation
+                            )
+                        } else {
+                            externalTerminalPlaceholder(for: session, message: "Session opened in Ghostty")
+                        }
                     } else if session.projectPath != nil && !sessionStore.activeXcodeProjects.contains(session.projectName) {
                         // Xcode closed for this project
                         placeholderView("Xcode project not open")
@@ -212,10 +217,14 @@ struct PanelContentView: View {
                                 }
                             }
                     } else {
-                        placeholderView("Click a project tab to start a terminal session")
-                            .onTapGesture {
-                                sessionStore.startSessionIfNeeded(session.id)
-                            }
+                        if settings.terminalBackend == .embedded {
+                            placeholderView("Click a project tab to start a terminal session")
+                                .onTapGesture {
+                                    sessionStore.startSessionIfNeeded(session.id)
+                                }
+                        } else {
+                            externalTerminalPlaceholder(for: session, message: ghosttyMessage)
+                        }
                     }
                 } else if sessionStore.sessions.isEmpty {
                     placeholderView("No Xcode projects detected.\nClick + to create a new session.")
@@ -269,6 +278,67 @@ struct PanelContentView: View {
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .opacity(0)
+            }
+    }
+
+    private var ghosttyMessage: String {
+        if !TerminalManager.shared.isGhosttyAvailable {
+            return "Ghostty isn't installed. Install it or switch back to the embedded terminal backend."
+        }
+
+        if !TerminalManager.shared.supportsGhosttyAutomation {
+            let version = TerminalManager.shared.ghosttyVersion ?? "unknown"
+            return "Ghostty \(version) is installed, but Notchy needs Ghostty 1.3.0 or newer for automation."
+        }
+
+        return "Open this session in Ghostty"
+    }
+
+    @ViewBuilder
+    private func externalTerminalPlaceholder(for session: TerminalSession, message: String) -> some View {
+        Color(nsColor: NSColor(white: 0.1, alpha: 1.0))
+            .overlay {
+                VStack(spacing: 12) {
+                    Text(message)
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    if TerminalManager.shared.supportsGhosttyAutomation {
+                        Button(session.hasStarted ? "Reopen in Ghostty" : "Open in Ghostty") {
+                            sessionStore.restartSession(session.id)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.white.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    } else if !TerminalManager.shared.isGhosttyAvailable {
+                        Button("Download Ghostty") {
+                            NSWorkspace.shared.open(URL(string: "https://ghostty.org/download")!)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.white.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    } else {
+                        Button("Download Ghostty 1.3+") {
+                            NSWorkspace.shared.open(URL(string: "https://ghostty.org/download")!)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.white.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                }
             }
     }
 }

--- a/Notchy/SessionStore.swift
+++ b/Notchy/SessionStore.swift
@@ -235,7 +235,13 @@ class SessionStore {
     func startSessionIfNeeded(_ id: UUID) {
         guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
         if !sessions[index].hasStarted {
-            sessions[index].hasStarted = true
+            let session = sessions[index]
+            let started = TerminalManager.shared.launchConfiguredTerminal(
+                for: id,
+                workingDirectory: session.workingDirectory,
+                launchClaude: session.projectPath != nil
+            )
+            sessions[index].hasStarted = started
         }
     }
 
@@ -413,6 +419,8 @@ class SessionStore {
         TerminalManager.shared.destroyTerminal(for: id)
         sessions[index].terminalStatus = .idle
         sessions[index].generation += 1
+        sessions[index].hasStarted = false
+        startSessionIfNeeded(id)
     }
 
     func closeSession(_ id: UUID) {

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+enum TerminalBackend: String, CaseIterable, Identifiable {
+    case embedded
+    case ghostty
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .embedded: return "Embedded"
+        case .ghostty: return "Ghostty"
+        }
+    }
+}
+
 @Observable
 class SettingsManager {
     static let shared = SettingsManager()
@@ -24,6 +38,10 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(hoverToOpenEnabled, forKey: "hoverToOpenEnabled") }
     }
 
+    var terminalBackend: TerminalBackend {
+        didSet { UserDefaults.standard.set(terminalBackend.rawValue, forKey: "terminalBackend") }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
@@ -31,11 +49,13 @@ class SettingsManager {
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
         if defaults.object(forKey: "hoverToOpenEnabled") == nil { defaults.set(true, forKey: "hoverToOpenEnabled") }
+        if defaults.object(forKey: "terminalBackend") == nil { defaults.set(TerminalBackend.embedded.rawValue, forKey: "terminalBackend") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
         hoverToOpenEnabled = defaults.bool(forKey: "hoverToOpenEnabled")
+        terminalBackend = TerminalBackend(rawValue: defaults.string(forKey: "terminalBackend") ?? "") ?? .embedded
     }
 }

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -20,16 +20,22 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(claudeIntegrationEnabled, forKey: "claudeIntegrationEnabled") }
     }
 
+    var hoverToOpenEnabled: Bool {
+        didSet { UserDefaults.standard.set(hoverToOpenEnabled, forKey: "hoverToOpenEnabled") }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
         if defaults.object(forKey: "soundsEnabled") == nil { defaults.set(true, forKey: "soundsEnabled") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
+        if defaults.object(forKey: "hoverToOpenEnabled") == nil { defaults.set(true, forKey: "hoverToOpenEnabled") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
+        hoverToOpenEnabled = defaults.bool(forKey: "hoverToOpenEnabled")
     }
 }

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -33,7 +33,7 @@ struct SettingsContentView: View {
                 .tabItem { Label(SettingsTab.integrations.rawValue, systemImage: SettingsTab.integrations.icon) }
                 .tag(SettingsTab.integrations)
         }
-        .frame(width: 450, height: 240)
+        .frame(width: 450, height: 300)
     }
 }
 
@@ -43,6 +43,16 @@ struct GeneralTab: View {
 
     var body: some View {
         Form {
+            Picker("Terminal backend", selection: $settings.terminalBackend) {
+                ForEach(TerminalBackend.allCases) { backend in
+                    Text(backend.title).tag(backend)
+                }
+            }
+            Text(settings.terminalBackend == .ghostty
+                 ? "Ghostty opens sessions in an external window and requires Ghostty 1.3+ for automation. Live Claude status stays in the embedded backend for now."
+                 : "Embedded uses Notchy's built-in SwiftTerm terminal and supports live Claude status.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             Toggle("Show notch overlay", isOn: $settings.showNotch)
                 .onChange(of: settings.showNotch) { _, newValue in
                     onShowNotchChanged?(newValue)
@@ -119,7 +129,7 @@ class SettingsWindowController {
         let hostingView = NSHostingView(rootView: content)
 
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 450, height: 240),
+            contentRect: NSRect(x: 0, y: 0, width: 450, height: 300),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -47,6 +47,7 @@ struct GeneralTab: View {
                 .onChange(of: settings.showNotch) { _, newValue in
                     onShowNotchChanged?(newValue)
                 }
+            Toggle("Open panel on notch hover", isOn: $settings.hoverToOpenEnabled)
             Toggle("Enable sounds", isOn: $settings.soundsEnabled)
         }
         .padding(20)

--- a/Notchy/TerminalManager.swift
+++ b/Notchy/TerminalManager.swift
@@ -193,8 +193,44 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
 
 class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
     static let shared = TerminalManager()
+    private static let ghosttyApplicationName = "Ghostty"
+    private static let ghosttyBundleIdentifier = "com.mitchellh.ghostty"
+    private static let minimumGhosttyAutomationVersion = "1.3.0"
 
     private var terminals: [UUID: LocalProcessTerminalView] = [:]
+
+    private var ghosttyAppURL: URL? {
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Self.ghosttyBundleIdentifier) {
+            return appURL
+        }
+
+        let localApplications = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Applications/Ghostty.app")
+        if FileManager.default.fileExists(atPath: localApplications.path) {
+            return localApplications
+        }
+
+        let systemApplications = URL(fileURLWithPath: "/Applications/Ghostty.app")
+        if FileManager.default.fileExists(atPath: systemApplications.path) {
+            return systemApplications
+        }
+
+        return nil
+    }
+
+    var isGhosttyAvailable: Bool {
+        ghosttyAppURL != nil
+    }
+
+    var ghosttyVersion: String? {
+        guard let appURL = ghosttyAppURL,
+              let bundle = Bundle(url: appURL) else { return nil }
+        return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    var supportsGhosttyAutomation: Bool {
+        guard let version = ghosttyVersion else { return false }
+        return version.compare(Self.minimumGhosttyAutomationVersion, options: .numeric) != .orderedAscending
+    }
 
     func terminal(for sessionId: UUID, workingDirectory: String, launchClaude: Bool = true) -> LocalProcessTerminalView {
         if let existing = terminals[sessionId] {
@@ -233,6 +269,37 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
         return terminal
     }
 
+    @discardableResult
+    func launchConfiguredTerminal(for sessionId: UUID, workingDirectory: String, launchClaude: Bool = true) -> Bool {
+        switch SettingsManager.shared.terminalBackend {
+        case .embedded:
+            _ = terminal(for: sessionId, workingDirectory: workingDirectory, launchClaude: launchClaude)
+            return true
+        case .ghostty:
+            return launchGhostty(workingDirectory: workingDirectory, launchClaude: launchClaude)
+        }
+    }
+
+    @discardableResult
+    func launchGhostty(workingDirectory: String, launchClaude: Bool = true) -> Bool {
+        guard supportsGhosttyAutomation else { return false }
+
+        let command = launchClaude && SettingsManager.shared.claudeIntegrationEnabled ? "claude" : nil
+        let script = ghosttyAppleScript(workingDirectory: workingDirectory, command: command)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - LocalProcessTerminalViewDelegate
 
     func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
@@ -265,6 +332,34 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
         env["TERM"] = "xterm-256color"
         env["LANG"] = env["LANG"] ?? "en_US.UTF-8"
         return env.map { "\($0.key)=\($0.value)" }
+    }
+
+    private func ghosttyAppleScript(workingDirectory: String, command: String?) -> String {
+        let escapedDirectory = appleScriptString(workingDirectory)
+        var lines = [
+            "tell application \"\(Self.ghosttyApplicationName)\"",
+            "activate",
+            "set cfg to new surface configuration",
+            "set initial working directory of cfg to \"\(escapedDirectory)\""
+        ]
+
+        if let command {
+            let escapedCommand = appleScriptString(command)
+            lines.append("set command of cfg to \"\(escapedCommand)\"")
+        }
+
+        lines.append(contentsOf: [
+            "set win to new window with configuration cfg"
+        ])
+
+        lines.append("end tell")
+        return lines.joined(separator: "\n")
+    }
+
+    private func appleScriptString(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
     private func shellEscape(_ path: String) -> String {


### PR DESCRIPTION
## Summary
- add a persisted setting to disable automatic notch hover activation
- gate notch hover and drag-over opening behind that setting
- keep menu bar and hotkey activation unchanged

## Why
Automatic notch hover can block top-center controls in remote desktop, VPS, and similar apps. This lets users keep the notch overlay without forcing hover-open behavior.

## Testing
- built locally with `xcodebuild -project Notchy.xcodeproj -scheme Notchy -configuration Debug build`
- verified the updated app launches from `~/Applications/Notchy.app`