### PR TITLE
feat: terminal UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 # Build/ is tracked intentionally (public download artifact)
 !Build/
+build/
 DerivedData/
 *.xcodeproj/xcuserdata/
 *.xcworkspace/xcuserdata/

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>teamID</key>
+	<string>2Y5BF8JZF6</string>
+</dict>
+</plist>

--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var panel: TerminalPanel!
@@ -9,7 +10,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var hoverHideTimer: Timer?
     private var hoverGlobalMonitor: Any?
     private var hoverLocalMonitor: Any?
-    private var hotkeyMonitor: Any?
     /// Whether the panel was opened via notch hover (vs status item click)
     private var panelOpenedViaHover = false
     private let hoverMargin: CGFloat = 15
@@ -29,8 +29,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
-            button.image = NSImage(named: "menuIcon") //NSImage(systemSymbolName: "terminal", accessibilityDescription: "Notchy")
-            button.image?.isTemplate = true  // lets macOS handle light/dark mode
+            button.image = NSImage(named: "menuIcon")
+            button.image?.isTemplate = true
             button.target = self
             button.action = #selector(statusItemClicked(_:))
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
@@ -39,19 +39,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupPanel() {
         panel = TerminalPanel(sessionStore: sessionStore)
-        // When the panel hides for any reason, clean up hover tracking
-        NotificationCenter.default.addObserver(
-            forName: NSWindow.didResignKeyNotification,
-            object: panel,
-            queue: .main
-        ) { [weak self] _ in
-            guard let self, !self.panel.isVisible else { return }
-            self.notchWindow?.endHover()
-            self.panelOpenedViaHover = false
-            self.stopHoverTracking()
-        }
-        // When panel becomes key (user clicked on it), stop hover tracking
-        // since resign-key will handle hiding from here
         NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: panel,
@@ -61,8 +48,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if self.panelOpenedViaHover {
                 self.panelOpenedViaHover = false
                 self.stopHoverTracking()
-                // Panel is now in "click mode" — shrink the notch hover state
-                // since hover tracking is no longer managing it
                 self.notchWindow?.endHover()
             }
         }
@@ -73,31 +58,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.notchHovered()
         }
         notchWindow?.isPanelVisible = { [weak self] in
-            self?.panel.isVisible ?? false
+            self?.panel.isShown ?? false
         }
     }
 
     private func setupHotkey() {
-        // Global monitor: fires when another app is focused (backtick = keyCode 50)
-        hotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.keyCode == 50,
-                  event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.function).isEmpty
-            else { return }
-            DispatchQueue.main.async { self?.togglePanel() }
+        HotkeyManager.shared.onHotkey = { [weak self] in
+            self?.togglePanel()
+        }
+        HotkeyManager.shared.setup()
+
+        // Re-check when app becomes active (user may have just granted permission in System Settings)
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            HotkeyManager.shared.recheckIfNeeded()
         }
     }
 
     private func notchHovered() {
-        guard !panel.isVisible else { return }
-        showPanelBelowNotch()
+        guard !panel.isShown else { return }
+        panel.showPanel()
         panelOpenedViaHover = true
         startHoverTracking()
         sessionStore.detectAndSwitchAsync()
-    }
-
-    private func showPanelBelowNotch() {
-        guard let screen = NSScreen.builtIn else { return }
-        panel.showPanelCentered(on: screen)
     }
 
     // MARK: - Hover-to-hide tracking
@@ -127,7 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func checkHoverBounds() {
-        guard panel.isVisible, panelOpenedViaHover, !sessionStore.isPinned, !sessionStore.isShowingDialog else {
+        guard panel.isShown, panelOpenedViaHover, !sessionStore.isShowingDialog else {
             cancelHoverHide()
             return
         }
@@ -147,11 +133,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard hoverHideTimer == nil else { return }
         hoverHideTimer = Timer.scheduledTimer(withTimeInterval: hoverHideDelay, repeats: false) { [weak self] _ in
             guard let self else { return }
-            // Re-check one more time before hiding (mouse may have returned)
             let mouse = NSEvent.mouseLocation
             let inNotch = self.notchWindow?.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse) ?? false
             let inPanel = self.panel.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse)
-            if !inNotch && !inPanel && !self.sessionStore.isPinned && !self.sessionStore.isShowingDialog {
+            if !inNotch && !inPanel && !self.sessionStore.isShowingDialog {
                 self.panel.hidePanel()
                 self.notchWindow?.endHover()
                 self.panelOpenedViaHover = false
@@ -169,18 +154,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         showContextMenu()
     }
 
-    private func togglePanel() {
-        if panel.isVisible {
+    func togglePanel() {
+        guard !panel.isAnimating else { return }
+        if panel.isShown {
             panel.hidePanel()
             notchWindow?.endHover()
             panelOpenedViaHover = false
             stopHoverTracking()
         } else {
             panelOpenedViaHover = false
-            // Show panel immediately
-            showPanelBelowStatusItem()
-
-            // Then detect projects in background
+            panel.showPanel()
             sessionStore.detectAndSwitchAsync()
         }
     }
@@ -237,7 +220,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func selectSession(_ sender: NSMenuItem) {
         guard let sessionId = sender.representedObject as? UUID else { return }
         sessionStore.selectSession(sessionId)
-        showPanelBelowStatusItem()
+        panel.showPanel()
     }
 
     @objc private func createCheckpoint(_ sender: NSMenuItem) {
@@ -268,16 +251,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func createNewSession() {
         sessionStore.createQuickSession()
-        showPanelBelowStatusItem()
-    }
-
-    private func showPanelBelowStatusItem() {
-        if let button = statusItem.button,
-           let window = button.window {
-            let buttonRect = button.convert(button.bounds, to: nil)
-            let screenRect = window.convertToScreen(buttonRect)
-            panel.showPanel(below: screenRect)
-        }
+        panel.showPanel()
     }
 
 }

--- a/Notchy/HotkeyManager.swift
+++ b/Notchy/HotkeyManager.swift
@@ -1,0 +1,227 @@
+import AppKit
+import Carbon
+
+/// Manages global hotkey (Ctrl+`) with a layered fallback strategy:
+/// Layer 1: CGEvent tap (.defaultTap) — requires Accessibility permission
+/// Layer 2: Carbon RegisterEventHotKey — legacy fallback
+/// Layer 3: NSEvent.addGlobalMonitorForEvents — requires Input Monitoring
+/// Always: NSEvent.addLocalMonitorForEvents — for own-app events (no permission needed)
+final class HotkeyManager {
+    static let shared = HotkeyManager()
+
+    var onHotkey: (() -> Void)?
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var carbonHotkeyRef: EventHotKeyRef?
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+    private(set) var activeLayer: String = "none"
+
+    // Target key: Ctrl+` (backtick, keyCode 50)
+    private static let targetKeyCode: UInt16 = 50
+
+    func setup() {
+        // Always install local monitor (no permission needed)
+        installLocalMonitor()
+
+        // Layer 1: CGEvent tap (best — uses Accessibility permission)
+        if CGPreflightPostEventAccess() {
+            if installCGEventTap() {
+                activeLayer = "CGEvent tap"
+                print("[Notchy] Global hotkey: active via CGEvent tap")
+                return
+            }
+        }
+
+        // Layer 2: Carbon RegisterEventHotKey
+        if installCarbonHotKey() {
+            activeLayer = "Carbon hotkey"
+            print("[Notchy] Global hotkey: active via Carbon RegisterEventHotKey")
+            return
+        }
+
+        // Layer 3: NSEvent global monitor (needs Input Monitoring)
+        if CGPreflightListenEventAccess() {
+            installNSEventGlobalMonitor()
+            activeLayer = "NSEvent global monitor"
+            print("[Notchy] Global hotkey: active via NSEvent global monitor")
+            return
+        }
+
+        // All layers failed
+        activeLayer = "none"
+        print("[Notchy] Global hotkey: FAILED — no permission layer succeeded")
+        requestPermission()
+    }
+
+    /// Re-check permissions (call when app becomes active — user may have just granted in System Settings)
+    func recheckIfNeeded() {
+        guard activeLayer == "none" else { return }
+        setup()
+    }
+
+    func teardown() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
+            eventTap = nil
+            runLoopSource = nil
+        }
+        if let ref = carbonHotkeyRef {
+            UnregisterEventHotKey(ref)
+            carbonHotkeyRef = nil
+        }
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+        activeLayer = "none"
+    }
+
+    // MARK: - Layer 1: CGEvent tap
+
+    private func installCGEventTap() -> Bool {
+        let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: { proxy, type, event, userInfo -> Unmanaged<CGEvent>? in
+                // Re-enable if macOS disabled the tap due to timeout
+                if type == .tapDisabledByTimeout {
+                    if let userInfo = userInfo {
+                        let mgr = Unmanaged<HotkeyManager>.fromOpaque(userInfo).takeUnretainedValue()
+                        if let tap = mgr.eventTap {
+                            CGEvent.tapEnable(tap: tap, enable: true)
+                        }
+                    }
+                    return Unmanaged.passUnretained(event)
+                }
+
+                guard type == .keyDown else {
+                    return Unmanaged.passUnretained(event)
+                }
+
+                let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+                let flags = event.flags
+
+                // Ctrl+` : keyCode 50, Control only
+                guard keyCode == 50,
+                      flags.contains(.maskControl),
+                      !flags.contains(.maskCommand),
+                      !flags.contains(.maskAlternate)
+                else {
+                    return Unmanaged.passUnretained(event)
+                }
+
+                if let userInfo = userInfo {
+                    let mgr = Unmanaged<HotkeyManager>.fromOpaque(userInfo).takeUnretainedValue()
+                    DispatchQueue.main.async { mgr.onHotkey?() }
+                }
+                return nil // consume the event
+            },
+            userInfo: refcon
+        ) else {
+            return false
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        self.eventTap = tap
+        self.runLoopSource = source
+        return true
+    }
+
+    // MARK: - Layer 2: Carbon RegisterEventHotKey
+
+    private func installCarbonHotKey() -> Bool {
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, _, _ -> OSStatus in
+                DispatchQueue.main.async { HotkeyManager.shared.onHotkey?() }
+                return noErr
+            },
+            1, &eventType, nil, nil
+        )
+        guard handlerStatus == noErr else { return false }
+
+        var hotKeyID = EventHotKeyID(signature: 0x4E544359, id: 1)
+        let regStatus = RegisterEventHotKey(
+            50, UInt32(controlKey), hotKeyID,
+            GetApplicationEventTarget(), 0, &carbonHotkeyRef
+        )
+        return regStatus == noErr
+    }
+
+    // MARK: - Layer 3: NSEvent global monitor
+
+    private func installNSEventGlobalMonitor() {
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == Self.targetKeyCode,
+                  event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.control)
+            else { return }
+            DispatchQueue.main.async { self?.onHotkey?() }
+        }
+    }
+
+    // MARK: - Local monitor (always installed)
+
+    private func installLocalMonitor() {
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == Self.targetKeyCode,
+                  event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.control)
+            else { return event }
+            DispatchQueue.main.async { self?.onHotkey?() }
+            return nil
+        }
+    }
+
+    // MARK: - Permission handling
+
+    private func requestPermission() {
+        // First try requesting programmatically
+        CGRequestPostEventAccess()
+
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Global Hotkey Unavailable"
+            alert.informativeText = """
+                Notchy needs Accessibility permission to register the global hotkey (Ctrl+`).
+
+                Go to System Settings → Privacy & Security → Accessibility and add Notchy.
+
+                If Notchy is already listed, remove it and re-add it — \
+                rebuilding the app can invalidate the previous permission.
+                """
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Open System Settings")
+            alert.addButton(withTitle: "Later")
+
+            NSApp.activate(ignoringOtherApps: true)
+            let response = alert.runModal()
+
+            if response == .alertFirstButtonReturn {
+                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+    }
+}

--- a/Notchy/PanelContentView.swift
+++ b/Notchy/PanelContentView.swift
@@ -23,9 +23,83 @@ struct WindowDragArea: NSViewRepresentable {
         override func mouseDown(with event: NSEvent) {
             if event.clickCount == 2 {
                 onDoubleClick?()
-            } else {
-                window?.performDrag(with: event)
             }
+        }
+    }
+}
+
+/// Drag handle at the bottom of the quake panel for resizing height.
+struct ResizeHandleView: NSViewRepresentable {
+    func makeNSView(context: Context) -> ResizeHandleNSView {
+        ResizeHandleNSView()
+    }
+
+    func updateNSView(_ nsView: ResizeHandleNSView, context: Context) {}
+
+    class ResizeHandleNSView: NSView {
+        private var initialMouseY: CGFloat = 0
+        private var initialPanelFrame: NSRect = .zero
+        private let grabberLayer = CAShapeLayer()
+
+        override init(frame: NSRect) {
+            super.init(frame: frame)
+            wantsLayer = true
+            setupGrabber()
+        }
+
+        required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            wantsLayer = true
+            setupGrabber()
+        }
+
+        private func setupGrabber() {
+            grabberLayer.fillColor = NSColor.white.withAlphaComponent(0.3).cgColor
+            layer?.addSublayer(grabberLayer)
+        }
+
+        override func layout() {
+            super.layout()
+            let pillWidth: CGFloat = 32
+            let pillHeight: CGFloat = 4
+            let pillRect = CGRect(
+                x: (bounds.width - pillWidth) / 2,
+                y: (bounds.height - pillHeight) / 2,
+                width: pillWidth,
+                height: pillHeight
+            )
+            grabberLayer.path = CGPath(roundedRect: pillRect, cornerWidth: 2, cornerHeight: 2, transform: nil)
+        }
+
+        override func resetCursorRects() {
+            addCursorRect(bounds, cursor: .resizeUpDown)
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            initialMouseY = NSEvent.mouseLocation.y
+            initialPanelFrame = window?.frame ?? .zero
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard let window = window, let screen = window.screen ?? NSScreen.main else { return }
+            let currentMouseY = NSEvent.mouseLocation.y
+            let deltaY = initialMouseY - currentMouseY
+            let newHeight = max(200, min(initialPanelFrame.height + deltaY, screen.visibleFrame.height))
+            let visibleTop = screen.visibleFrame.maxY
+            // Keep the panel's top edge anchored at the bottom of the menu bar,
+            // and preserve horizontal position (centered width).
+            let newFrame = NSRect(
+                x: initialPanelFrame.origin.x,
+                y: visibleTop - newHeight,
+                width: initialPanelFrame.width,
+                height: newHeight
+            )
+            window.setFrame(newFrame, display: true)
+        }
+
+        override func mouseUp(with event: NSEvent) {
+            guard let window = window else { return }
+            SettingsManager.shared.panelHeight = window.frame.height
         }
     }
 }
@@ -48,10 +122,10 @@ struct PanelContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Black top border — separate element so it pushes content down
+            // Top spacing so content clears the rounded corner area
             Rectangle()
-                .fill(Color.black)
-                .frame(height: 10)
+                .fill(Color.clear)
+                .frame(height: 6)
 
             // Top bar: tabs + controls
             HStack(spacing: 8) {
@@ -111,7 +185,7 @@ struct PanelContentView: View {
                 .padding(.trailing, -10)
             }
             .padding(.horizontal, 12)
-            .background(Color(nsColor: NSColor(white: 0.14, alpha: 1.0)).opacity(chromeBackgroundOpacity))
+            .background(Color.white.opacity(0.06))
 
             if sessionStore.isTerminalExpanded, sessionStore.checkpointStatus != nil || sessionStore.lastCheckpoint != nil {
                 HStack(spacing: 6) {
@@ -177,7 +251,7 @@ struct PanelContentView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(Color(nsColor: NSColor(white: 0.18, alpha: 1.0)).opacity(chromeBackgroundOpacity))
+                .background(Color.white.opacity(0.04))
                 .foregroundColor(.white.opacity(0.8))
             }
 
@@ -223,10 +297,13 @@ struct PanelContentView: View {
                     placeholderView("Select a project to begin")
                 }
             }
+
+            // Resize handle at bottom edge
+            ResizeHandleView()
+                .frame(height: 8)
+                .background(Color.white.opacity(0.04))
         }
-        .clipShape(UnevenRoundedRectangle(topLeadingRadius: 8.5, bottomLeadingRadius: 0, bottomTrailingRadius: 0, topTrailingRadius: 8.5))
-        .background(Color(nsColor: NSColor(white: 0.1, alpha: 1.0)).opacity(chromeBackgroundOpacity))
-        .clipShape(UnevenRoundedRectangle(topLeadingRadius: 8.5, bottomLeadingRadius: 0, bottomTrailingRadius: 0, topTrailingRadius: 8.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
         .onAppear {
             sessionStore.refreshLastCheckpoint()
         }
@@ -262,7 +339,7 @@ struct PanelContentView: View {
     }
 
     private func placeholderView(_ message: String) -> some View {
-        Color(nsColor: NSColor(white: 0.1, alpha: 1.0))
+        Color.clear
             .overlay {
                 Text(message)
                     .font(.system(size: 13))

--- a/Notchy/SessionStore.swift
+++ b/Notchy/SessionStore.swift
@@ -212,6 +212,22 @@ class SessionStore {
         return false
     }
 
+    func selectNextSession() {
+        guard sessions.count > 1,
+              let currentIndex = sessions.firstIndex(where: { $0.id == activeSessionId })
+        else { return }
+        let nextIndex = (currentIndex + 1) % sessions.count
+        selectSession(sessions[nextIndex].id)
+    }
+
+    func selectPreviousSession() {
+        guard sessions.count > 1,
+              let currentIndex = sessions.firstIndex(where: { $0.id == activeSessionId })
+        else { return }
+        let prevIndex = (currentIndex - 1 + sessions.count) % sessions.count
+        selectSession(sessions[prevIndex].id)
+    }
+
     /// Select a tab — auto-starts the terminal only if the project's Xcode instance is active
     func selectSession(_ id: UUID) {
         activeSessionId = id

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -20,16 +20,22 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(claudeIntegrationEnabled, forKey: "claudeIntegrationEnabled") }
     }
 
+    var panelHeight: CGFloat {
+        didSet { UserDefaults.standard.set(Double(panelHeight), forKey: "panelHeight") }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
         if defaults.object(forKey: "soundsEnabled") == nil { defaults.set(true, forKey: "soundsEnabled") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
+        if defaults.object(forKey: "panelHeight") == nil { defaults.set(400.0, forKey: "panelHeight") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
+        panelHeight = CGFloat(defaults.double(forKey: "panelHeight"))
     }
 }

--- a/Notchy/TerminalManager.swift
+++ b/Notchy/TerminalManager.swift
@@ -4,6 +4,7 @@ import SwiftTerm
 class ClickThroughTerminalView: LocalProcessTerminalView {
     var sessionId: UUID?
     private var keyMonitor: Any?
+    private var scrollMonitor: Any?
     private var statusDebounceWork: DispatchWorkItem?
     private static let statusQueue = DispatchQueue(label: "com.notchy.status", qos: .utility)
 
@@ -13,16 +14,21 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
         super.init(frame: frame)
         registerForDraggedTypes([.fileURL])
         installArrowKeyMonitor()
+        installScrollMonitor()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         registerForDraggedTypes([.fileURL])
         installArrowKeyMonitor()
+        installScrollMonitor()
     }
 
     deinit {
         if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let monitor = scrollMonitor {
             NSEvent.removeMonitor(monitor)
         }
     }
@@ -32,6 +38,18 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
     private func installArrowKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self = self, self.window?.firstResponder === self else { return event }
+
+            // Shift+Enter → send newline without submitting (for multi-line input)
+            if event.keyCode == 36 && event.modifierFlags.contains(.shift) {
+                self.send(txt: "\n")
+                return nil
+            }
+
+            // Cmd+Backspace → kill line (send Ctrl-U to clear from cursor to start of line)
+            if event.keyCode == 51 && event.modifierFlags.contains(.command) {
+                self.send(txt: "\u{15}")
+                return nil
+            }
 
             let arrowCode: String?
             switch event.keyCode {
@@ -53,6 +71,44 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
                 if mods.contains(.option) { modifier += 2 }
                 if mods.contains(.control) { modifier += 4 }
                 self.send(txt: "\u{1b}[1;\(modifier)\(code)")
+            }
+            return nil // consume the event
+        }
+    }
+
+    /// Intercept scroll wheel events when the terminal is in alternate screen mode.
+    /// - Mouse mode ON: forward as mouse button 4/5 presses (TUI handles scrolling)
+    /// - Mouse mode OFF: send UP/DOWN arrow key sequences (like iTerm2's
+    ///   "Send scroll events to alternate screen" option)
+    private func installScrollMonitor() {
+        scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+            guard let self = self, self.window?.firstResponder === self else { return event }
+
+            let terminal = self.getTerminal()
+            guard terminal.isCurrentBufferAlternate else { return event }
+            guard event.deltaY != 0 else { return event }
+
+            let lines = max(1, Int(abs(event.deltaY)))
+            let count = min(lines, 5)
+
+            if terminal.mouseMode != .off {
+                // Mouse mode: forward as mouse button 4 (scroll up) / 5 (scroll down)
+                let button = event.deltaY > 0 ? 4 : 5
+                let flags = terminal.encodeButton(
+                    button: button, release: false,
+                    shift: event.modifierFlags.contains(.shift),
+                    meta: event.modifierFlags.contains(.option),
+                    control: event.modifierFlags.contains(.control)
+                )
+                for _ in 0..<count {
+                    terminal.sendEvent(buttonFlags: flags, x: 0, y: 0)
+                }
+            } else {
+                // No mouse mode: send arrow key sequences so the TUI can scroll
+                let arrow = event.deltaY > 0 ? "A" : "B" // A = Up, B = Down
+                for _ in 0..<count {
+                    self.send(txt: "\u{1b}[\(arrow)")
+                }
             }
             return nil // consume the event
         }
@@ -205,10 +261,16 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
         terminal.sessionId = sessionId
         terminal.processDelegate = self
 
-        // Match macOS Terminal default font size
-        terminal.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        terminal.nativeBackgroundColor = NSColor(white: 0.1, alpha: 1.0)
-        terminal.nativeForegroundColor = NSColor(white: 0.9, alpha: 1.0)
+        // Use Nerd Font for Unicode/Powerline glyph support, fall back to system mono
+        if let nerdFont = NSFont(name: "MesloLGSDZNF-Regular", size: 13) {
+            terminal.font = nerdFont
+        } else if let nerdFont = NSFont(name: "MesloLGLNF-Regular", size: 13) {
+            terminal.font = nerdFont
+        } else {
+            terminal.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        }
+        terminal.nativeBackgroundColor = NSColor(white: 0.05, alpha: 0.6)
+        terminal.nativeForegroundColor = NSColor(white: 0.95, alpha: 1.0)
 
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let environment = buildEnvironment()

--- a/Notchy/TerminalPanel.swift
+++ b/Notchy/TerminalPanel.swift
@@ -7,15 +7,15 @@ class ClickThroughHostingView<Content: View>: NSHostingView<Content> {
 
 class TerminalPanel: NSPanel {
     private let sessionStore: SessionStore
-    private static let collapsedHeight: CGFloat = 44
-    private var expandedHeight: CGFloat = 500
+    private(set) var isAnimating = false
+    private(set) var isShown = false
 
     init(sessionStore: SessionStore) {
         self.sessionStore = sessionStore
 
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 720, height: 400),
-            styleMask: [.borderless, .resizable, .fullSizeContentView, .nonactivatingPanel],
+            styleMask: [.borderless, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
             defer: true
         )
@@ -28,27 +28,48 @@ class TerminalPanel: NSPanel {
         isOpaque = false
         animationBehavior = .none
         hidesOnDeactivate = false
-        minSize = NSSize(width: 480, height: 300)
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
-        let contentView = PanelContentView(
+        // Base layer: NSVisualEffectView for frosted glass blur
+        let visualEffect = NSVisualEffectView()
+        visualEffect.material = .hudWindow
+        visualEffect.blendingMode = .behindWindow
+        visualEffect.state = .active
+        visualEffect.wantsLayer = true
+        visualEffect.layer?.cornerRadius = 8
+        visualEffect.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                              .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        visualEffect.layer?.masksToBounds = true
+
+        let swiftUIContent = PanelContentView(
             sessionStore: sessionStore,
             onClose: { [weak self] in self?.hidePanel() },
             onToggleExpand: { [weak self] in self?.handleToggleExpand() }
         )
-        let hosting = ClickThroughHostingView(rootView: contentView)
-        self.contentView = hosting
+        let hosting = ClickThroughHostingView(rootView: swiftUIContent)
+        hosting.translatesAutoresizingMaskIntoConstraints = false
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(windowDidResignKey),
-            name: NSWindow.didResignKeyNotification,
-            object: self
-        )
+        visualEffect.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: visualEffect.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: visualEffect.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: visualEffect.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: visualEffect.bottomAnchor),
+        ])
+
+        self.contentView = visualEffect
 
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(windowDidBecomeKey),
             name: NSWindow.didBecomeKeyNotification,
+            object: self
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidResignKey),
+            name: NSWindow.didResignKeyNotification,
             object: self
         )
 
@@ -67,54 +88,92 @@ class TerminalPanel: NSPanel {
         )
     }
 
-    func showPanel(below rect: NSRect) {
-        if let screen = NSScreen.main {
-            let panelWidth = frame.width
-            let panelHeight = frame.height
-            let x = rect.midX - panelWidth / 2
-            let y = screen.visibleFrame.maxY - panelHeight
-            setFrameOrigin(NSPoint(x: x, y: y))
+    func showPanel() {
+        guard !isAnimating, !isShown else {
+            if isShown { makeKeyAndOrderFront(nil) }
+            return
         }
-        makeKeyAndOrderFront(nil)
-        NotificationCenter.default.post(name: .NotchyNotchStatusChanged, object: nil)
-    }
+        guard let screen = NSScreen.main else { return }
 
-    func showPanelCentered(on screen: NSScreen) {
+        let panelHeight = SettingsManager.shared.panelHeight
+        let panelWidth = frame.width  // preserve current width
         let screenFrame = screen.frame
-        let panelWidth = frame.width
-        let panelHeight = frame.height
-        let x = screenFrame.midX - panelWidth / 2
-        let y = screenFrame.maxY - panelHeight
-        setFrameOrigin(NSPoint(x: x, y: y))
+        let visibleTop = screen.visibleFrame.maxY  // bottom of menu bar
+        let centerX = screenFrame.midX - panelWidth / 2
+
+        // Start hidden: tucked behind the menu bar/notch
+        let hiddenFrame = NSRect(
+            x: centerX,
+            y: visibleTop,
+            width: panelWidth,
+            height: panelHeight
+        )
+        setFrame(hiddenFrame, display: false)
         makeKeyAndOrderFront(nil)
+
+        // Animate sliding down: top edge anchored at bottom of menu bar
+        let shownFrame = NSRect(
+            x: centerX,
+            y: visibleTop - panelHeight,
+            width: panelWidth,
+            height: panelHeight
+        )
+
+        isAnimating = true
+        isShown = true
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.25
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            ctx.allowsImplicitAnimation = true
+            self.animator().setFrame(shownFrame, display: true)
+        }, completionHandler: { [weak self] in
+            self?.isAnimating = false
+        })
+
         NotificationCenter.default.post(name: .NotchyNotchStatusChanged, object: nil)
     }
 
     func hidePanel() {
-        orderOut(nil)
+        guard !isAnimating, isShown else { return }
+        guard let screen = NSScreen.main else {
+            orderOut(nil)
+            isShown = false
+            return
+        }
+
+        let visibleTop = screen.visibleFrame.maxY
+        // Slide up behind the menu bar/notch
+        let hiddenFrame = NSRect(
+            x: frame.origin.x,
+            y: visibleTop,
+            width: frame.width,
+            height: frame.height
+        )
+
+        isAnimating = true
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.2
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            ctx.allowsImplicitAnimation = true
+            self.animator().setFrame(hiddenFrame, display: true)
+        }, completionHandler: { [weak self] in
+            self?.orderOut(nil)
+            self?.isAnimating = false
+            self?.isShown = false
+        })
     }
 
-    private func handleToggleExpand() {
-        updateOpacity()
-        if sessionStore.isTerminalExpanded {
-            // Expanding: restore saved height, anchor top edge
-            let newHeight = expandedHeight
-            var newFrame = frame
-            newFrame.origin.y -= (newHeight - frame.height)
-            newFrame.size.height = newHeight
-            minSize = NSSize(width: 480, height: 300)
-            setFrame(newFrame, display: true, animate: false)
-        } else {
-            // Collapsing: save current height, shrink to tab bar only
-            expandedHeight = frame.height
-            let newHeight = Self.collapsedHeight
-            var newFrame = frame
-            newFrame.origin.y += (frame.height - newHeight)
-            newFrame.size.height = newHeight
-            minSize = NSSize(width: 480, height: Self.collapsedHeight)
-            setFrame(newFrame, display: true, animate: false)
-        }
+    /// Reposition the panel to match current screen geometry (e.g. after resize drag).
+    func repositionToScreen() {
+        guard isShown, let screen = NSScreen.main else { return }
+        let visibleTop = screen.visibleFrame.maxY
+        var newFrame = frame
+        newFrame.origin.x = screen.frame.midX - newFrame.width / 2
+        newFrame.origin.y = visibleTop - newFrame.height
+        setFrame(newFrame, display: true)
     }
+
+    private func handleToggleExpand() {}
 
     @objc private func handleHidePanel() {
         hidePanel()
@@ -126,31 +185,18 @@ class TerminalPanel: NSPanel {
 
     @objc private func windowDidBecomeKey(_ notification: Notification) {
         sessionStore.panelDidBecomeKey()
-        updateOpacity()
     }
 
     @objc private func windowDidResignKey(_ notification: Notification) {
+        // Auto-hide when user clicks away, unless pinned or showing a dialog
         if !sessionStore.isPinned && !sessionStore.isShowingDialog && attachedSheet == nil && childWindows?.isEmpty ?? true {
             hidePanel()
         }
-        updateOpacity()
-    }
-
-    private func updateOpacity() {
-        let collapsed = !sessionStore.isTerminalExpanded
-        let unfocused = !isKeyWindow
-        // Collapsed + unfocused: dim the whole window
-        alphaValue = (collapsed && unfocused) ? 0.8 : 1.0
-        // Expanded + unfocused: clear window background so SwiftUI chrome
-        // transparency shows through (terminal stays opaque via its own view)
-        backgroundColor = .clear
     }
 
     override func sendEvent(_ event: NSEvent) {
         let wasKey = isKeyWindow
         super.sendEvent(event)
-        // When the panel wasn't key, the first click just activates the window.
-        // Re-send it so SwiftUI controls (tabs, buttons) process the click too.
         if !wasKey && event.type == .leftMouseDown {
             super.sendEvent(event)
         }
@@ -163,6 +209,15 @@ class TerminalPanel: NSPanel {
         }
         if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "t" {
             sessionStore.createQuickSession()
+            return true
+        }
+        // Ctrl+Tab / Ctrl+Shift+Tab: cycle tabs
+        if event.keyCode == 48 && event.modifierFlags.contains(.control) {
+            if event.modifierFlags.contains(.shift) {
+                sessionStore.selectPreviousSession()
+            } else {
+                sessionStore.selectNextSession()
+            }
             return true
         }
         return super.performKeyEquivalent(with: event)


### PR DESCRIPTION
## Summary

- **Slide-down panel** — smooth drop-down animation from behind the menu bar (0.25s ease-out open, 0.2s ease-in close), with auto-hide on resign-key
- **Fix terminal scrollback** — forwards scroll events to TUI apps (Claude Code, vim) using the alternate screen buffer, enabling scroll-up to read previous context
- **Global hotkey (Ctrl+`)** — layered fallback (CGEvent tap → Carbon → NSEvent monitor) with permission detection and user-facing alert when Accessibility isn't granted
- **Transparent blur background** — `NSVisualEffectView` with `.hudWindow` material for frosted glass look
- **Resizable panel height** — drag the bottom edge to resize; height persisted across launches
- **Tab cycling** — Ctrl+Tab / Ctrl+Shift+Tab to switch between sessions
- **Terminal shortcuts** — Shift+Enter (newline), Cmd+Backspace (kill line)
- **Nerd Font support** — uses MesloLGSDZ Nerd Font for Unicode/Powerline glyphs with system mono fallback
- **All Spaces** — panel available on every Space via `canJoinAllSpaces`

## Test plan

- [ ] Launch Notchy, verify panel slides down from behind the menu bar
- [ ] Press Ctrl+` to toggle panel open/close (grant Accessibility if prompted)
- [ ] Open Claude Code in a session, scroll up with trackpad to verify scrollback works
- [ ] Drag the bottom edge of the panel to resize, restart and verify height is preserved
- [ ] Press Ctrl+Tab to cycle between tabs
- [ ] Click away from the panel to verify auto-hide (unpin first)
- [ ] Verify transparent blur background is visible behind the panel