### PR TITLE
fix: hide notch UI on screens without a physical notch

### DIFF
--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let hoverMargin: CGFloat = 15
     private let hoverHideDelay: TimeInterval = 0.06
 
+    private var screenObserver: Any?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupStatusItem()
         setupPanel()
@@ -22,8 +24,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setupNotchWindow()
         }
         setupHotkey()
+        observeScreenChanges()
         // Detect in background so launch isn't blocked
         sessionStore.detectAllXcodeProjectsAsync()
+    }
+
+    /// Show or hide the notch window when displays change (e.g. dock/undock external monitor).
+    private func observeScreenChanges() {
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.settings.showNotch else { return }
+            if NSScreen.builtIn != nil {
+                // A screen with a notch is available — ensure the window exists
+                if self.notchWindow == nil { self.setupNotchWindow() }
+            } else {
+                // No notch screen — tear down
+                self.notchWindow?.orderOut(nil)
+                self.notchWindow = nil
+            }
+        }
     }
 
     private func setupStatusItem() {

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -289,12 +289,8 @@ class NotchWindow: NSPanel {
             // Notch spans the gap between the two auxiliary areas
             notchWidth = right.minX - left.maxX
             notchHeight = screen.frame.maxY - min(left.minY, right.minY)
-        } else {
-            // No notch (external display, older Mac) — use sensible defaults
-            let menuBarHeight = screen.frame.maxY - screen.visibleFrame.maxY
-            notchWidth = 180
-            notchHeight = max(menuBarHeight, 25)
         }
+        // builtIn already guarantees hasNotch, so no fallback needed
     }
 
     // MARK: - Positioning
@@ -439,12 +435,24 @@ class NotchWindow: NSPanel {
 // MARK: - NSScreen helper
 
 extension NSScreen {
-    /// Returns the built-in display (the one with the notch), or the main screen as fallback.
+    /// Whether this screen has a physical notch (auxiliary areas flanking the camera housing).
+    @available(macOS 12.0, *)
+    var hasNotch: Bool {
+        auxiliaryTopLeftArea != nil && auxiliaryTopRightArea != nil
+    }
+
+    /// Returns the built-in display **only if it has a notch**. Returns `nil` otherwise
+    /// (e.g. clamshell mode with an external monitor, older MacBooks, Mac mini/Pro).
     static var builtIn: NSScreen? {
-        screens.first { screen in
+        guard let screen = screens.first(where: { screen in
             let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
             return CGDisplayIsBuiltin(id) != 0
-        } ?? main
+        }) else { return nil }
+
+        if #available(macOS 12.0, *) {
+            return screen.hasNotch ? screen : nil
+        }
+        return nil
     }
 }
 


### PR DESCRIPTION
## Summary
- `NSScreen.builtIn` now returns `nil` when the built-in display lacks `auxiliaryTopLeftArea`/`auxiliaryTopRightArea`, instead of falling back to `NSScreen.main`
- The notch pill no longer renders on external monitors or older MacBooks without a notch
- `AppDelegate` observes `didChangeScreenParametersNotification` to dynamically tear down or recreate the notch window when displays are connected/disconnected

## Test plan
- [ ] Run on MacBook with notch → notch pill appears normally
- [ ] Connect external monitor, move app focus there → notch pill stays only on built-in display
- [ ] Use clamshell mode (lid closed, external only) → no notch pill visible
- [ ] Disconnect external monitor → notch pill reappears on built-in display
- [ ] Toggle "Show notch" in Settings → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)