### PR TITLE
Add external display trigger for webcam hover zones

### DIFF
--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -4,6 +4,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var panel: TerminalPanel!
     private var notchWindow: NotchWindow?
+    /// NotchWindows for external displays, keyed by CGDirectDisplayID.
+    private var externalNotchWindows: [CGDirectDisplayID: NotchWindow] = [:]
+    private var screenChangeObserver: Any?
     private let sessionStore = SessionStore.shared
     private let settings = SettingsManager.shared
     private var hoverHideTimer: Timer?
@@ -12,6 +15,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyMonitor: Any?
     /// Whether the panel was opened via notch hover (vs status item click)
     private var panelOpenedViaHover = false
+    /// The screen that triggered the current hover-opened panel.
+    private var hoverTriggerScreen: NSScreen?
     private let hoverMargin: CGFloat = 15
     private let hoverHideDelay: TimeInterval = 0.06
 
@@ -22,6 +27,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setupNotchWindow()
         }
         setupHotkey()
+        if settings.externalDisplayTrigger {
+            setupExternalDisplayWindows()
+        }
+        observeScreenChanges()
         // Detect in background so launch isn't blocked
         sessionStore.detectAllXcodeProjectsAsync()
     }
@@ -47,7 +56,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] _ in
             guard let self, !self.panel.isVisible else { return }
             self.notchWindow?.endHover()
+            for window in self.externalNotchWindows.values { window.endHover() }
             self.panelOpenedViaHover = false
+            self.hoverTriggerScreen = nil
             self.stopHoverTracking()
         }
         // When panel becomes key (user clicked on it), stop hover tracking
@@ -60,17 +71,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             if self.panelOpenedViaHover {
                 self.panelOpenedViaHover = false
+                self.hoverTriggerScreen = nil
                 self.stopHoverTracking()
                 // Panel is now in "click mode" — shrink the notch hover state
                 // since hover tracking is no longer managing it
                 self.notchWindow?.endHover()
+                for window in self.externalNotchWindows.values { window.endHover() }
             }
         }
     }
 
     private func setupNotchWindow() {
         notchWindow = NotchWindow { [weak self] in
-            self?.notchHovered()
+            self?.notchHovered(on: NSScreen.builtIn)
         }
         notchWindow?.isPanelVisible = { [weak self] in
             self?.panel.isVisible ?? false
@@ -87,17 +100,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func notchHovered() {
+    private func notchHovered(on screen: NSScreen? = nil) {
         guard !panel.isVisible else { return }
-        showPanelBelowNotch()
+        let targetScreen = screen ?? NSScreen.builtIn ?? NSScreen.main!
+        hoverTriggerScreen = targetScreen
+        panel.showPanelCentered(on: targetScreen)
         panelOpenedViaHover = true
         startHoverTracking()
         sessionStore.detectAndSwitchAsync()
-    }
-
-    private func showPanelBelowNotch() {
-        guard let screen = NSScreen.builtIn else { return }
-        panel.showPanelCentered(on: screen)
     }
 
     // MARK: - Hover-to-hide tracking
@@ -134,9 +144,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let mouse = NSEvent.mouseLocation
         let inNotch = notchWindow?.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse) ?? false
+        let inExternalNotch = externalNotchWindows.values.contains { $0.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse) }
         let inPanel = panel.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse)
 
-        if inNotch || inPanel {
+        if inNotch || inExternalNotch || inPanel {
             cancelHoverHide()
         } else {
             scheduleHoverHide()
@@ -150,11 +161,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Re-check one more time before hiding (mouse may have returned)
             let mouse = NSEvent.mouseLocation
             let inNotch = self.notchWindow?.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse) ?? false
+            let inExternalNotch = self.externalNotchWindows.values.contains { $0.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse) }
             let inPanel = self.panel.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse)
-            if !inNotch && !inPanel && !self.sessionStore.isPinned && !self.sessionStore.isShowingDialog {
+            if !inNotch && !inExternalNotch && !inPanel && !self.sessionStore.isPinned && !self.sessionStore.isShowingDialog {
                 self.panel.hidePanel()
                 self.notchWindow?.endHover()
+                for window in self.externalNotchWindows.values { window.endHover() }
                 self.panelOpenedViaHover = false
+                self.hoverTriggerScreen = nil
                 self.stopHoverTracking()
             }
         }
@@ -173,7 +187,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if panel.isVisible {
             panel.hidePanel()
             notchWindow?.endHover()
+            for window in externalNotchWindows.values { window.endHover() }
             panelOpenedViaHover = false
+            hoverTriggerScreen = nil
             stopHoverTracking()
         } else {
             panelOpenedViaHover = false
@@ -255,15 +271,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openSettings() {
-        SettingsWindowController.shared.show { [weak self] showNotch in
-            guard let self else { return }
-            if showNotch {
-                if self.notchWindow == nil { self.setupNotchWindow() }
-            } else {
-                self.notchWindow?.orderOut(nil)
-                self.notchWindow = nil
+        SettingsWindowController.shared.show(
+            onShowNotchChanged: { [weak self] showNotch in
+                guard let self else { return }
+                if showNotch {
+                    if self.notchWindow == nil { self.setupNotchWindow() }
+                } else {
+                    self.notchWindow?.orderOut(nil)
+                    self.notchWindow = nil
+                }
+            },
+            onExternalDisplayChanged: { [weak self] enabled in
+                guard let self else { return }
+                if enabled {
+                    self.setupExternalDisplayWindows()
+                } else {
+                    self.teardownExternalDisplayWindows()
+                }
             }
-        }
+        )
     }
 
     @objc private func createNewSession() {
@@ -278,6 +304,48 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let screenRect = window.convertToScreen(buttonRect)
             panel.showPanel(below: screenRect)
         }
+    }
+
+    // MARK: - External display management
+
+    private func observeScreenChanges() {
+        screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.settings.externalDisplayTrigger else { return }
+            self.setupExternalDisplayWindows()
+        }
+    }
+
+    private func setupExternalDisplayWindows() {
+        let externalScreens = NSScreen.externalScreens
+        // Remove windows for screens that are no longer connected
+        let currentIDs = Set(externalScreens.map { $0.displayID })
+        for id in externalNotchWindows.keys where !currentIDs.contains(id) {
+            externalNotchWindows[id]?.orderOut(nil)
+            externalNotchWindows.removeValue(forKey: id)
+        }
+        // Create windows for newly connected screens
+        for screen in externalScreens {
+            let id = screen.displayID
+            guard externalNotchWindows[id] == nil else { continue }
+            let window = NotchWindow(screenID: id) { [weak self, weak screen] in
+                self?.notchHovered(on: screen)
+            }
+            window.isPanelVisible = { [weak self] in
+                self?.panel.isVisible ?? false
+            }
+            externalNotchWindows[id] = window
+        }
+    }
+
+    private func teardownExternalDisplayWindows() {
+        for (_, window) in externalNotchWindows {
+            window.orderOut(nil)
+        }
+        externalNotchWindows.removeAll()
     }
 
 }

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -17,6 +17,9 @@ class NotchWindow: NSPanel {
     /// When the panel is visible, the notch stays in hover-grown size.
     var isPanelVisible: (() -> Bool)?
 
+    /// The screen this notch window targets (nil = built-in display).
+    private let targetScreenID: CGDirectDisplayID?
+
     /// Detected notch dimensions (updated on screen change).
     private var notchWidth: CGFloat = 180
     private var notchHeight: CGFloat = 37
@@ -36,7 +39,12 @@ class NotchWindow: NSPanel {
     /// SwiftUI content overlay shown inside the pill when expanded
     private var pillContentHost: NSHostingView<NotchPillContent>?
 
-    init(onHover: @escaping () -> Void) {
+    /// Creates a NotchWindow for the given screen.
+    /// - Parameters:
+    ///   - screenID: The CGDirectDisplayID to target, or nil for the built-in display.
+    ///   - onHover: Called when the mouse enters the trigger zone.
+    init(screenID: CGDirectDisplayID? = nil, onHover: @escaping () -> Void) {
+        self.targetScreenID = screenID
         self.onHover = onHover
 
         super.init(
@@ -174,7 +182,7 @@ class NotchWindow: NSPanel {
 
     private func expandWithBounce() {
         isExpanded = true
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
 
         let targetWidth: CGFloat = notchWidth + 80
@@ -228,7 +236,7 @@ class NotchWindow: NSPanel {
             self.pillContentHost?.animator().alphaValue = 0
         }
 
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
 
         var targetFrame = NSRect(
@@ -281,7 +289,7 @@ class NotchWindow: NSPanel {
     // MARK: - Notch size detection
 
     private func detectNotchSize() {
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
 
         if #available(macOS 12.0, *),
            let left = screen.auxiliaryTopLeftArea,
@@ -300,7 +308,7 @@ class NotchWindow: NSPanel {
     // MARK: - Positioning
 
     private func positionAtNotch() {
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let x = screenFrame.midX - notchWidth / 2
         let y = screenFrame.maxY - notchHeight
@@ -325,7 +333,7 @@ class NotchWindow: NSPanel {
         let mouseLocation = NSEvent.mouseLocation
 
         // Check the notch area itself
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let effectiveWidth = isExpanded ? notchWidth + 80 : notchWidth
         let notchRect = NSRect(
@@ -407,7 +415,7 @@ class NotchWindow: NSPanel {
         pillView.isHovered = false
         pillView.earProtrusion = 0
         pillContentHost?.rootView = NotchPillContent(isHovering: false)
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let baseWidth = isExpanded ? notchWidth + 80 : notchWidth
         let targetFrame = NSRect(
@@ -432,6 +440,17 @@ class NotchWindow: NSPanel {
         }
     }
 
+    /// Resolves the screen this notch window targets.
+    private var resolvedScreen: NSScreen? {
+        if let id = targetScreenID {
+            return NSScreen.screens.first { screen in
+                let screenID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
+                return screenID == id
+            }
+        }
+        return NSScreen.builtIn
+    }
+
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 }
@@ -439,12 +458,19 @@ class NotchWindow: NSPanel {
 // MARK: - NSScreen helper
 
 extension NSScreen {
+    /// The CGDirectDisplayID for this screen.
+    var displayID: CGDirectDisplayID {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
+    }
+
     /// Returns the built-in display (the one with the notch), or the main screen as fallback.
     static var builtIn: NSScreen? {
-        screens.first { screen in
-            let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
-            return CGDisplayIsBuiltin(id) != 0
-        } ?? main
+        screens.first { CGDisplayIsBuiltin($0.displayID) != 0 } ?? main
+    }
+
+    /// Returns all external (non-built-in) screens.
+    static var externalScreens: [NSScreen] {
+        screens.filter { CGDisplayIsBuiltin($0.displayID) == 0 }
     }
 }
 

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -20,16 +20,22 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(claudeIntegrationEnabled, forKey: "claudeIntegrationEnabled") }
     }
 
+    var externalDisplayTrigger: Bool {
+        didSet { UserDefaults.standard.set(externalDisplayTrigger, forKey: "externalDisplayTrigger") }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
         if defaults.object(forKey: "soundsEnabled") == nil { defaults.set(true, forKey: "soundsEnabled") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
+        if defaults.object(forKey: "externalDisplayTrigger") == nil { defaults.set(false, forKey: "externalDisplayTrigger") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
+        externalDisplayTrigger = defaults.bool(forKey: "externalDisplayTrigger")
     }
 }

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -18,6 +18,7 @@ enum SettingsTab: String, CaseIterable {
 struct SettingsContentView: View {
     @State private var selectedTab: SettingsTab = .about
     var onShowNotchChanged: ((Bool) -> Void)?
+    var onExternalDisplayChanged: ((Bool) -> Void)?
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -25,7 +26,7 @@ struct SettingsContentView: View {
                 .tabItem { Label(SettingsTab.about.rawValue, systemImage: SettingsTab.about.icon) }
                 .tag(SettingsTab.about)
 
-            GeneralTab(onShowNotchChanged: onShowNotchChanged)
+            GeneralTab(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
                 .tabItem { Label(SettingsTab.general.rawValue, systemImage: SettingsTab.general.icon) }
                 .tag(SettingsTab.general)
 
@@ -40,6 +41,7 @@ struct SettingsContentView: View {
 struct GeneralTab: View {
     @Bindable private var settings = SettingsManager.shared
     var onShowNotchChanged: ((Bool) -> Void)?
+    var onExternalDisplayChanged: ((Bool) -> Void)?
 
     var body: some View {
         Form {
@@ -47,6 +49,15 @@ struct GeneralTab: View {
                 .onChange(of: settings.showNotch) { _, newValue in
                     onShowNotchChanged?(newValue)
                 }
+            Toggle(isOn: $settings.externalDisplayTrigger) {
+                Text("External display trigger")
+                Text("Hover the top-center of external displays to open the panel")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .onChange(of: settings.externalDisplayTrigger) { _, newValue in
+                onExternalDisplayChanged?(newValue)
+            }
             Toggle("Enable sounds", isOn: $settings.soundsEnabled)
         }
         .padding(20)
@@ -106,7 +117,7 @@ class SettingsWindowController {
     static let shared = SettingsWindowController()
     private var window: NSWindow?
 
-    func show(onShowNotchChanged: @escaping (Bool) -> Void) {
+    func show(onShowNotchChanged: @escaping (Bool) -> Void, onExternalDisplayChanged: @escaping (Bool) -> Void) {
         if let existing = window {
             existing.level = .floating
             existing.makeKeyAndOrderFront(nil)
@@ -114,7 +125,7 @@ class SettingsWindowController {
             return
         }
 
-        let content = SettingsContentView(onShowNotchChanged: onShowNotchChanged)
+        let content = SettingsContentView(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
         let hostingView = NSHostingView(rootView: content)
 
         let win = NSWindow(


### PR DESCRIPTION
## Summary
- Adds hover-to-open trigger zones at the top-center of external displays (e.g. Apple Studio Displays), mirroring the built-in notch behavior
- New "External display trigger" toggle in Settings > General (off by default)
- NotchWindows are automatically created/removed as displays connect/disconnect
- Refactors `NotchWindow` to accept a target screen parameter instead of hardcoding `NSScreen.builtIn`

## Test plan
- [ ] Enable "External display trigger" in Settings with an external display connected — hover top-center of external display should open the panel
- [ ] Verify the panel appears centered on the correct external display
- [ ] Verify hover auto-hide still works correctly (moving mouse away from panel and trigger zone hides panel)
- [ ] Disconnect/reconnect external display while setting is enabled — trigger zones should update
- [ ] Verify built-in notch hover behavior is unchanged
- [ ] Verify the setting persists across app restarts
- [ ] Verify toggling the setting off removes external trigger zones immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)