### PR TITLE
Mute sounds during video calls when microphone is active

### DIFF
--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -4,6 +4,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var panel: TerminalPanel!
     private var notchWindow: NotchWindow?
+    /// NotchWindows for external displays, keyed by CGDirectDisplayID.
+    private var externalNotchWindows: [CGDirectDisplayID: NotchWindow] = [:]
+    private var screenChangeObserver: Any?
     private let sessionStore = SessionStore.shared
     private let settings = SettingsManager.shared
     private var hoverHideTimer: Timer?
@@ -12,6 +15,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyMonitor: Any?
     /// Whether the panel was opened via notch hover (vs status item click)
     private var panelOpenedViaHover = false
+    /// The screen that triggered the current hover-opened panel.
+    private var hoverTriggerScreen: NSScreen?
     private let hoverMargin: CGFloat = 15
     private let hoverHideDelay: TimeInterval = 0.06
 
@@ -22,6 +27,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setupNotchWindow()
         }
         setupHotkey()
+        if settings.externalDisplayTrigger {
+            setupExternalDisplayWindows()
+        }
+        observeScreenChanges()
         // Detect in background so launch isn't blocked
         sessionStore.detectAllXcodeProjectsAsync()
     }
@@ -47,7 +56,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] _ in
             guard let self, !self.panel.isVisible else { return }
             self.notchWindow?.endHover()
+            for window in self.externalNotchWindows.values { window.endHover() }
             self.panelOpenedViaHover = false
+            self.hoverTriggerScreen = nil
             self.stopHoverTracking()
         }
         // When panel becomes key (user clicked on it), stop hover tracking
@@ -60,17 +71,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             if self.panelOpenedViaHover {
                 self.panelOpenedViaHover = false
+                self.hoverTriggerScreen = nil
                 self.stopHoverTracking()
                 // Panel is now in "click mode" — shrink the notch hover state
                 // since hover tracking is no longer managing it
                 self.notchWindow?.endHover()
+                for window in self.externalNotchWindows.values { window.endHover() }
             }
         }
     }
 
     private func setupNotchWindow() {
         notchWindow = NotchWindow { [weak self] in
-            self?.notchHovered()
+            self?.notchHovered(on: NSScreen.builtIn)
         }
         notchWindow?.isPanelVisible = { [weak self] in
             self?.panel.isVisible ?? false
@@ -87,17 +100,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func notchHovered() {
+    private func notchHovered(on screen: NSScreen? = nil) {
         guard !panel.isVisible else { return }
-        showPanelBelowNotch()
+        let targetScreen = screen ?? NSScreen.builtIn ?? NSScreen.main!
+        hoverTriggerScreen = targetScreen
+        panel.showPanelCentered(on: targetScreen)
         panelOpenedViaHover = true
         startHoverTracking()
         sessionStore.detectAndSwitchAsync()
-    }
-
-    private func showPanelBelowNotch() {
-        guard let screen = NSScreen.builtIn else { return }
-        panel.showPanelCentered(on: screen)
     }
 
     // MARK: - Hover-to-hide tracking
@@ -134,9 +144,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let mouse = NSEvent.mouseLocation
         let inNotch = notchWindow?.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse) ?? false
+        let inExternalNotch = externalNotchWindows.values.contains { $0.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse) }
         let inPanel = panel.frame.insetBy(dx: -hoverMargin, dy: -hoverMargin).contains(mouse)
 
-        if inNotch || inPanel {
+        if inNotch || inExternalNotch || inPanel {
             cancelHoverHide()
         } else {
             scheduleHoverHide()
@@ -150,11 +161,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Re-check one more time before hiding (mouse may have returned)
             let mouse = NSEvent.mouseLocation
             let inNotch = self.notchWindow?.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse) ?? false
+            let inExternalNotch = self.externalNotchWindows.values.contains { $0.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse) }
             let inPanel = self.panel.frame.insetBy(dx: -self.hoverMargin, dy: -self.hoverMargin).contains(mouse)
-            if !inNotch && !inPanel && !self.sessionStore.isPinned && !self.sessionStore.isShowingDialog {
+            if !inNotch && !inExternalNotch && !inPanel && !self.sessionStore.isPinned && !self.sessionStore.isShowingDialog {
                 self.panel.hidePanel()
                 self.notchWindow?.endHover()
+                for window in self.externalNotchWindows.values { window.endHover() }
                 self.panelOpenedViaHover = false
+                self.hoverTriggerScreen = nil
                 self.stopHoverTracking()
             }
         }
@@ -173,7 +187,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if panel.isVisible {
             panel.hidePanel()
             notchWindow?.endHover()
+            for window in externalNotchWindows.values { window.endHover() }
             panelOpenedViaHover = false
+            hoverTriggerScreen = nil
             stopHoverTracking()
         } else {
             panelOpenedViaHover = false
@@ -255,15 +271,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openSettings() {
-        SettingsWindowController.shared.show { [weak self] showNotch in
-            guard let self else { return }
-            if showNotch {
-                if self.notchWindow == nil { self.setupNotchWindow() }
-            } else {
-                self.notchWindow?.orderOut(nil)
-                self.notchWindow = nil
+        SettingsWindowController.shared.show(
+            onShowNotchChanged: { [weak self] showNotch in
+                guard let self else { return }
+                if showNotch {
+                    if self.notchWindow == nil { self.setupNotchWindow() }
+                } else {
+                    self.notchWindow?.orderOut(nil)
+                    self.notchWindow = nil
+                }
+            },
+            onExternalDisplayChanged: { [weak self] enabled in
+                guard let self else { return }
+                if enabled {
+                    self.setupExternalDisplayWindows()
+                } else {
+                    self.teardownExternalDisplayWindows()
+                }
             }
-        }
+        )
     }
 
     @objc private func createNewSession() {
@@ -278,6 +304,48 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let screenRect = window.convertToScreen(buttonRect)
             panel.showPanel(below: screenRect)
         }
+    }
+
+    // MARK: - External display management
+
+    private func observeScreenChanges() {
+        screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.settings.externalDisplayTrigger else { return }
+            self.setupExternalDisplayWindows()
+        }
+    }
+
+    private func setupExternalDisplayWindows() {
+        let externalScreens = NSScreen.externalScreens
+        // Remove windows for screens that are no longer connected
+        let currentIDs = Set(externalScreens.map { $0.displayID })
+        for id in externalNotchWindows.keys where !currentIDs.contains(id) {
+            externalNotchWindows[id]?.orderOut(nil)
+            externalNotchWindows.removeValue(forKey: id)
+        }
+        // Create windows for newly connected screens
+        for screen in externalScreens {
+            let id = screen.displayID
+            guard externalNotchWindows[id] == nil else { continue }
+            let window = NotchWindow(screenID: id) { [weak self, weak screen] in
+                self?.notchHovered(on: screen)
+            }
+            window.isPanelVisible = { [weak self] in
+                self?.panel.isVisible ?? false
+            }
+            externalNotchWindows[id] = window
+        }
+    }
+
+    private func teardownExternalDisplayWindows() {
+        for (_, window) in externalNotchWindows {
+            window.orderOut(nil)
+        }
+        externalNotchWindows.removeAll()
     }
 
 }

--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -331,8 +331,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         for screen in externalScreens {
             let id = screen.displayID
             guard externalNotchWindows[id] == nil else { continue }
-            let window = NotchWindow(screenID: id) { [weak self, weak screen] in
-                self?.notchHovered(on: screen)
+            // Capture displayID and resolve the live NSScreen at hover time —
+            // a `weak` NSScreen reference can go nil when the screen array
+            // refreshes, which would silently fall back to the built-in display.
+            let window = NotchWindow(screenID: id) { [weak self] in
+                let liveScreen = NSScreen.screens.first { $0.displayID == id }
+                self?.notchHovered(on: liveScreen)
             }
             window.isPanelVisible = { [weak self] in
                 self?.panel.isVisible ?? false

--- a/Notchy/AppDelegate.swift
+++ b/Notchy/AppDelegate.swift
@@ -31,8 +31,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setupExternalDisplayWindows()
         }
         observeScreenChanges()
+        // Boot a shell (+ claude) for every restored tab so they're warm before
+        // the panel is shown — otherwise only the active tab gets a terminal.
+        sessionStore.warmUpRestoredSessions()
         // Detect in background so launch isn't blocked
         sessionStore.detectAllXcodeProjectsAsync()
+        UsageMonitor.shared.start()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // Capture mid-typing drafts that updatePendingPromptText doesn't persist
+        // on every keystroke.
+        sessionStore.flushPersistence()
     }
 
     private func setupStatusItem() {
@@ -204,8 +214,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func showContextMenu() {
         let menu = NSMenu()
 
-        if !sessionStore.sessions.isEmpty {
-            for session in sessionStore.sessions {
+        let groups = sessionStore.projectGroups
+        let activeGroupId = sessionStore.activeProjectGroupId
+        let sessionsByGroup = Dictionary(grouping: sessionStore.sessions, by: { $0.groupId })
+        let orphanSessions = sessionsByGroup[nil] ?? []
+
+        if !groups.isEmpty {
+            for group in groups {
+                let item = NSMenuItem(
+                    title: group.name,
+                    action: #selector(selectGroup(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = group.id
+                if group.id == activeGroupId { item.state = .on }
+                menu.addItem(item)
+
+                let groupSessions = sessionsByGroup[group.id] ?? []
+                for session in groupSessions {
+                    let sub = NSMenuItem(
+                        title: session.projectName,
+                        action: #selector(selectSession(_:)),
+                        keyEquivalent: ""
+                    )
+                    sub.target = self
+                    sub.representedObject = session.id
+                    sub.indentationLevel = 1
+                    if session.id == sessionStore.activeSessionId { sub.state = .on }
+                    menu.addItem(sub)
+                }
+            }
+            menu.addItem(.separator())
+        }
+
+        if !orphanSessions.isEmpty {
+            for session in orphanSessions {
                 let item = NSMenuItem(
                     title: session.projectName,
                     action: #selector(selectSession(_:)),
@@ -213,6 +257,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
                 item.target = self
                 item.representedObject = session.id
+                if session.id == sessionStore.activeSessionId { item.state = .on }
                 menu.addItem(item)
             }
             menu.addItem(.separator())
@@ -253,6 +298,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func selectSession(_ sender: NSMenuItem) {
         guard let sessionId = sender.representedObject as? UUID else { return }
         sessionStore.selectSession(sessionId)
+        showPanelBelowStatusItem()
+    }
+
+    @objc private func selectGroup(_ sender: NSMenuItem) {
+        guard let groupId = sender.representedObject as? UUID else { return }
+        sessionStore.selectGroup(groupId)
         showPanelBelowStatusItem()
     }
 

--- a/Notchy/ClaudeAccount.swift
+++ b/Notchy/ClaudeAccount.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A named Claude Code account. Each account maps to its own config directory
+/// (`~/.notchy/accounts/<folderName>`), which is passed to the spawned shell as
+/// `CLAUDE_CONFIG_DIR`. That directory holds the account's own credentials, so
+/// assigning different accounts to different `ProjectGroup`s lets each project
+/// run `claude` logged in as a different user.
+///
+/// `folderName` is generated once at creation and never changes, so renaming the
+/// account (which only touches `name`) never orphans an existing login.
+struct ClaudeAccount: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String
+    let folderName: String
+
+    init(id: UUID = UUID(), name: String, folderName: String) {
+        self.id = id
+        self.name = name
+        self.folderName = folderName
+    }
+
+    /// Absolute config directory for this account, e.g. `~/.notchy/accounts/work-1a2b3c4d`.
+    var configDirURL: URL {
+        Self.accountsRoot.appendingPathComponent(folderName, isDirectory: true)
+    }
+
+    /// Root directory holding every account's config dir.
+    static var accountsRoot: URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".notchy/accounts", isDirectory: true)
+    }
+
+    /// Builds a stable, filesystem-safe folder name from the display name plus a
+    /// short slice of the account id (guards against collisions between accounts
+    /// that slug to the same string).
+    static func makeFolderName(from name: String, id: UUID) -> String {
+        let allowed = CharacterSet.alphanumerics
+        let slug = String(name.lowercased().unicodeScalars.map {
+            allowed.contains($0) ? Character($0) : "-"
+        })
+        let trimmed = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let base = trimmed.isEmpty ? "account" : trimmed
+        return "\(base)-\(id.uuidString.prefix(8).lowercased())"
+    }
+}

--- a/Notchy/ConductorView.swift
+++ b/Notchy/ConductorView.swift
@@ -1,0 +1,642 @@
+import SwiftUI
+
+/// Overview of every session: live status, per-tab prompt/response history
+/// with verification checkboxes, and a global Claude Code usage summary at
+/// the top. Arrow keys / Enter target the first session with pending choices.
+struct ConductorView: View {
+    @Bindable var sessionStore: SessionStore
+    var usageMonitor = UsageMonitor.shared
+    /// Called when the user clicks a session's project name to jump into it.
+    var onSessionSelected: ((UUID) -> Void)? = nil
+    /// Per-session keyboard highlight: signature (choice numbers) + selected index.
+    /// Signature lets us invalidate the override when a fresh prompt arrives.
+    @State private var localHighlights: [UUID: (signature: [Int], index: Int)] = [:]
+    @FocusState private var keyboardFocused: Bool
+    /// Captured at drag-start, cleared at drag-end. While non-nil we render
+    /// against this frozen list instead of `sessionStore.sessions` — keeps
+    /// the LazyVStack from re-diffing rows while the tab bar's drop delegate
+    /// rapidly mutates the underlying array (otherwise prone to crash).
+    @State private var dragSnapshot: [TerminalSession]?
+
+    private var displayedSessions: [TerminalSession] {
+        dragSnapshot ?? sessionStore.sessions
+    }
+
+    /// First session in display order with pending choices — this is the one
+    /// arrow keys/Enter target.
+    private var keyboardTarget: TerminalSession? {
+        displayedSessions.first(where: { !$0.pendingChoices.isEmpty })
+    }
+
+    private func highlightedNumber(for session: TerminalSession) -> Int? {
+        guard !session.pendingChoices.isEmpty else { return nil }
+        let sig = session.pendingChoices.map(\.number)
+        if let entry = localHighlights[session.id],
+           entry.signature == sig,
+           session.pendingChoices.indices.contains(entry.index) {
+            return session.pendingChoices[entry.index].number
+        }
+        return session.pendingChoices.first(where: { $0.isSelected })?.number
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                UsageHeader(monitor: usageMonitor)
+                    .padding(.bottom, 4)
+
+                if displayedSessions.isEmpty {
+                    Text("No sessions")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(0.5))
+                        .padding(.top, 40)
+                } else {
+                    ForEach(displayedSessions) { session in
+                        ConductorRow(
+                            session: session,
+                            sessionStore: sessionStore,
+                            highlightedNumber: highlightedNumber(for: session),
+                            onSessionSelected: onSessionSelected
+                        )
+                    }
+                }
+            }
+            .padding(12)
+        }
+        .background(Color(nsColor: NSColor(white: 0.1, alpha: 1.0)))
+        .focusable()
+        .focusEffectDisabled()
+        .focused($keyboardFocused)
+        .onAppear { keyboardFocused = keyboardTarget != nil }
+        .onChange(of: keyboardTarget?.id) { _, new in
+            if new != nil { keyboardFocused = true }
+        }
+        .onChange(of: sessionStore.draggedSessionId) { _, new in
+            if new != nil, dragSnapshot == nil {
+                dragSnapshot = sessionStore.sessions
+            } else if new == nil {
+                dragSnapshot = nil
+            }
+        }
+        .onKeyPress(.upArrow) { moveHighlight(by: -1) }
+        .onKeyPress(.downArrow) { moveHighlight(by: 1) }
+        .onKeyPress(.return) { submitHighlighted() }
+    }
+
+    private func currentIndex(in session: TerminalSession) -> Int {
+        let sig = session.pendingChoices.map(\.number)
+        if let entry = localHighlights[session.id],
+           entry.signature == sig,
+           session.pendingChoices.indices.contains(entry.index) {
+            return entry.index
+        }
+        return session.pendingChoices.firstIndex(where: { $0.isSelected }) ?? 0
+    }
+
+    private func moveHighlight(by delta: Int) -> KeyPress.Result {
+        guard let s = keyboardTarget, !s.pendingChoices.isEmpty else { return .ignored }
+        let count = s.pendingChoices.count
+        let next = (currentIndex(in: s) + delta + count) % count
+        localHighlights[s.id] = (s.pendingChoices.map(\.number), next)
+        return .handled
+    }
+
+    private func submitHighlighted() -> KeyPress.Result {
+        guard let s = keyboardTarget, !s.pendingChoices.isEmpty else { return .ignored }
+        let number = s.pendingChoices[currentIndex(in: s)].number
+        sessionStore.submitChoice(s.id, number: number)
+        return .handled
+    }
+}
+
+private struct ConductorRow: View {
+    let session: TerminalSession
+    @Bindable var sessionStore: SessionStore
+    /// When non-nil, overrides the terminal-buffer-derived `isSelected` for
+    /// visual highlighting. Reflects the conductor's keyboard cursor.
+    var highlightedNumber: Int? = nil
+    var onSessionSelected: ((UUID) -> Void)? = nil
+
+    private var statusLabel: String {
+        switch session.terminalStatus {
+        case .working: return "Working"
+        case .waitingForInput: return "Waiting for input"
+        case .interrupted: return "Interrupted"
+        case .taskCompleted: return "Done"
+        case .idle: return "Idle"
+        }
+    }
+
+    private var statusColor: Color {
+        switch session.terminalStatus {
+        case .working: return .yellow
+        case .waitingForInput: return .red
+        case .interrupted: return .orange
+        case .taskCompleted: return .green
+        case .idle: return .gray
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Button(action: {
+                    sessionStore.selectSession(session.id)
+                    onSessionSelected?(session.id)
+                }) {
+                    Text(session.projectName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+
+                StatusPill(label: statusLabel, color: statusColor)
+
+                if session.terminalStatus == .working, let started = session.workingStartedAt {
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(formatElapsed(context.date.timeIntervalSince(started)))
+                            .font(.system(size: 11, weight: .medium).monospacedDigit())
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                }
+
+                Spacer()
+
+                if !session.exchanges.isEmpty {
+                    let visible = session.exchanges.suffix(5)
+                    let verified = visible.filter(\.verified).count
+                    Text("\(verified)/\(visible.count) verified")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.45))
+                }
+            }
+
+            // Live draft (text the user is currently typing into Claude's input box).
+            // Suppress when a confirmation preview is showing — the preview is more relevant.
+            if let draft = session.pendingPromptText, !draft.isEmpty,
+               session.terminalStatus != .working,
+               session.pendingPromptPreview == nil {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text("Drafting:")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.5))
+                    Text(draft)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.75))
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                    Spacer(minLength: 0)
+                }
+            }
+
+            // Spinner / activity line during work
+            if session.terminalStatus == .working, let activity = session.activityLine {
+                Text(activity)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.55))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            // Numbered choices Claude is waiting on
+            if session.terminalStatus == .waitingForInput, !session.pendingChoices.isEmpty {
+                choicesView
+            }
+
+            // Exchange history — most recent first, capped at 5.
+            // When input is pending, collapse rows so the orange action card stays dominant.
+            if !session.exchanges.isEmpty {
+                let pending = session.terminalStatus == .waitingForInput && !session.pendingChoices.isEmpty
+                VStack(alignment: .leading, spacing: pending ? 3 : 6) {
+                    ForEach(session.exchanges.suffix(5).reversed()) { exchange in
+                        ExchangeRow(
+                            exchange: exchange,
+                            compact: pending,
+                            onToggle: { sessionStore.setExchangeVerified(session.id, exchangeId: exchange.id, !exchange.verified) }
+                        )
+                    }
+                }
+                .padding(.top, pending ? 2 : 0)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var choicesView: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let preview = session.pendingPromptPreview, !preview.isEmpty {
+                PromptPreviewView(text: preview)
+                    .padding(.bottom, 2)
+            }
+            if let question = session.pendingQuestion {
+                questionHeader(question)
+            }
+            ForEach(session.pendingChoices) { choice in
+                ChoiceButton(
+                    choice: choice,
+                    isHighlighted: highlightedNumber.map { $0 == choice.number } ?? choice.isSelected,
+                    onTap: { sessionStore.submitChoice(session.id, number: choice.number) }
+                )
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.orange.opacity(0.10))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.orange.opacity(0.55), lineWidth: 1)
+        )
+        .shadow(color: Color.orange.opacity(0.25), radius: 6, x: 0, y: 0)
+    }
+
+    @ViewBuilder
+    private func questionHeader(_ question: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Image(systemName: "arrow.right.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.orange)
+            Text(question)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.white)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(.bottom, 2)
+    }
+
+    private func formatElapsed(_ interval: TimeInterval) -> String {
+        let total = Int(interval)
+        let m = total / 60
+        let s = total % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+private struct ChoiceButton: View {
+    let choice: PromptChoice
+    let isHighlighted: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Text("\(choice.number)")
+                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                    .foregroundColor(isHighlighted ? .black : .white.opacity(0.85))
+                    .frame(width: 18, height: 18)
+                    .background(numberBackground)
+                Text(choice.label)
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.95))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(rowBackground)
+            .overlay(rowBorder)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var numberBackground: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(isHighlighted ? Color.orange : Color.white.opacity(0.12))
+    }
+
+    private var rowBackground: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(isHighlighted ? Color.orange.opacity(0.18) : Color.white.opacity(0.05))
+    }
+
+    private var rowBorder: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .stroke(isHighlighted ? Color.orange.opacity(0.7) : Color.white.opacity(0.10), lineWidth: 1)
+    }
+}
+
+private struct ExchangeRow: View {
+    let exchange: TaskExchange
+    /// When true, an active prompt is pending — show only one line and hide summary
+    /// detail so the orange action card stays visually dominant.
+    var compact: Bool = false
+    let onToggle: () -> Void
+
+    private var inProgress: Bool { exchange.completedAt == nil }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            if inProgress {
+                ProgressView()
+                    .controlSize(.mini)
+                    .padding(.top, 1)
+                    .frame(width: compact ? 12 : 14, height: compact ? 12 : 14)
+            } else if exchange.wasInterrupted {
+                Button(action: onToggle) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .font(.system(size: compact ? 12 : 14, weight: .regular))
+                        .foregroundColor(.orange)
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 1)
+            } else {
+                Button(action: onToggle) {
+                    Image(systemName: exchange.verified ? "checkmark.square.fill" : "square")
+                        .font(.system(size: compact ? 12 : 14, weight: .regular))
+                        .foregroundColor(exchange.verified ? .accentColor : .white.opacity(0.5))
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 1)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(exchange.prompt)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.white.opacity(exchange.verified || compact ? 0.45 : 0.9))
+                    .strikethrough(exchange.verified, color: .white.opacity(0.45))
+                    .lineLimit(compact || exchange.verified ? 1 : 3)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .contextMenu {
+                        Button("Copy Prompt") {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(exchange.prompt, forType: .string)
+                        }
+                    }
+
+                if !exchange.verified && !compact {
+                    summaryView
+                }
+            }
+        }
+        .padding(compact ? 5 : 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.white.opacity(exchange.verified ? 0.02 : 0.04))
+        )
+        .opacity(compact ? 0.55 : (exchange.verified ? 0.7 : 1.0))
+    }
+
+    @ViewBuilder
+    private var summaryView: some View {
+        switch exchange.summaryStatus {
+        case .generating:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.mini)
+                Text("Summarizing…")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+        case .ready:
+            if let summary = exchange.summary {
+                Text(summary)
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(exchange.verified ? 0.55 : 0.8))
+                    .strikethrough(exchange.verified, color: .white.opacity(0.45))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .failed:
+            Text("Couldn't generate summary (check API key in Settings → Integrations).")
+                .font(.system(size: 10))
+                .foregroundColor(.white.opacity(0.4))
+        case .none:
+            if exchange.completedAt == nil {
+                Text("In progress…")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+        }
+    }
+}
+
+/// Renders the scraped preview block above a confirmation question — typically
+/// a diff for an edit, a command body for a Bash prompt, or a URL for WebFetch.
+/// Lines starting with a number followed by `-`/`+` (diff markers from Claude's
+/// TUI) get tinted red/green; everything else is rendered as plain monospaced text.
+private struct PromptPreviewView: View {
+    let text: String
+
+    private var lines: [Substring] { text.split(separator: "\n", omittingEmptySubsequences: false) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                Text(String(line))
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(color(for: line))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.black.opacity(0.35))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    /// Tints diff lines red/green based on Claude TUI's `NNN -` / `NNN +` prefix.
+    /// Anything else (file headers, command bodies, URLs) stays neutral white.
+    private func color(for line: Substring) -> Color {
+        let stripped = line.drop(while: { $0 == " " })
+        let afterDigits = stripped.drop(while: { $0.isNumber })
+        guard afterDigits.count != stripped.count else {
+            return .white.opacity(0.78)
+        }
+        let trimmed = afterDigits.drop(while: { $0 == " " })
+        switch trimmed.first {
+        case "-": return Color.red.opacity(0.85)
+        case "+": return Color.green.opacity(0.85)
+        default:  return .white.opacity(0.78)
+        }
+    }
+}
+
+private struct StatusPill: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.white.opacity(0.8))
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(
+            Capsule().fill(color.opacity(0.15))
+        )
+    }
+}
+
+private struct UsageHeader: View {
+    @Bindable var monitor: UsageMonitor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "gauge.with.dots.needle.50percent")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+                Text("Claude Code Usage")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.85))
+                Spacer()
+                if monitor.isRefreshing {
+                    ProgressView().controlSize(.mini)
+                } else if let fetched = monitor.snapshot?.fetchedAt {
+                    Text(timeAgo(fetched))
+                        .font(.system(size: 9))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                Button(action: { monitor.refreshNow() }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.5))
+                }
+                .buttonStyle(.plain)
+                .help("Refresh now")
+            }
+
+            if let snap = monitor.snapshot {
+                if let plan = snap.plan {
+                    Text(plan)
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.55))
+                }
+                if !snap.windows.isEmpty {
+                    HStack(alignment: .top, spacing: 14) {
+                        ForEach(snap.windows) { window in
+                            UsagePie(window: window)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+                if snap.windows.isEmpty, snap.plan == nil {
+                    Text("Couldn't parse /usage output.")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            } else if let err = monitor.lastError {
+                Text(err)
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+            } else {
+                Text("Fetching usage…")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private func timeAgo(_ date: Date) -> String {
+        let secs = Int(Date().timeIntervalSince(date))
+        if secs < 5 { return "just now" }
+        if secs < 60 { return "\(secs)s ago" }
+        let m = secs / 60
+        return "\(m)m ago"
+    }
+}
+
+private struct UsagePie: View {
+    let window: UsageWindow
+
+    private var fraction: CGFloat {
+        CGFloat(max(0, min(window.percent, 100))) / 100.0
+    }
+
+    private var pieColor: Color {
+        if window.percent >= 90 { return .red }
+        if window.percent >= 70 { return .orange }
+        return .green
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(Color.white.opacity(0.08))
+                PieSliceShape(fraction: fraction)
+                    .fill(pieColor)
+                Circle()
+                    .stroke(Color.white.opacity(0.12), lineWidth: 0.5)
+            }
+            .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(window.label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.white.opacity(0.78))
+                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Text("\(window.percent)%")
+                        .font(.system(size: 10, weight: .semibold).monospacedDigit())
+                        .foregroundColor(pieColor.opacity(0.95))
+                    if let resets = window.resets {
+                        Text("· \(resets)")
+                            .font(.system(size: 9))
+                            .foregroundColor(.white.opacity(0.45))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .help(window.resets.map { "\(window.label): \(window.percent)% · \($0)" } ?? "\(window.label): \(window.percent)%")
+    }
+}
+
+/// Center-anchored wedge that grows counter-clockwise from 12 o'clock.
+private struct PieSliceShape: Shape {
+    var fraction: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        guard fraction > 0 else { return p }
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        let start = Angle.degrees(-90)
+        let end = Angle.degrees(-90 - 360 * Double(min(fraction, 1)))
+        p.move(to: center)
+        // SwiftUI's `clockwise` is inverted from screen direction (y-down), so
+        // `clockwise: true` here draws counter-clockwise on screen.
+        p.addArc(center: center, radius: radius, startAngle: start, endAngle: end, clockwise: true)
+        p.closeSubpath()
+        return p
+    }
+}

--- a/Notchy/MicrophoneActivityMonitor.swift
+++ b/Notchy/MicrophoneActivityMonitor.swift
@@ -2,38 +2,75 @@ import Foundation
 import CoreAudio
 
 enum MicrophoneActivityMonitor {
+    /// True if any audio device with input streams is currently running.
+    /// We can't rely on the default input device alone — Teams, Zoom, etc.
+    /// frequently route through a specific device (headset, virtual mic)
+    /// that isn't the system default.
     static var isInputDeviceActive: Bool {
-        var deviceID = AudioDeviceID(0)
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        var defaultAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        for deviceID in allAudioDevices() where deviceHasInputStreams(deviceID) {
+            if deviceIsRunningSomewhere(deviceID) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func allAudioDevices() -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
-        let defaultStatus = AudioObjectGetPropertyData(
+        var dataSize: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(
             AudioObjectID(kAudioObjectSystemObject),
-            &defaultAddress,
+            &address,
             0, nil,
-            &size,
-            &deviceID
+            &dataSize
         )
-        guard defaultStatus == noErr, deviceID != 0 else { return false }
+        guard sizeStatus == noErr, dataSize > 0 else { return [] }
 
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        var devices = [AudioDeviceID](repeating: 0, count: count)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0, nil,
+            &dataSize,
+            &devices
+        )
+        guard status == noErr else { return [] }
+        return devices
+    }
+
+    private static func deviceHasInputStreams(_ deviceID: AudioDeviceID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        let status = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize)
+        guard status == noErr else { return false }
+        return dataSize > 0
+    }
+
+    private static func deviceIsRunningSomewhere(_ deviceID: AudioDeviceID) -> Bool {
         var isRunning: UInt32 = 0
-        var runningSize = UInt32(MemoryLayout<UInt32>.size)
-        var runningAddress = AudioObjectPropertyAddress(
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
-        let runningStatus = AudioObjectGetPropertyData(
+        let status = AudioObjectGetPropertyData(
             deviceID,
-            &runningAddress,
+            &address,
             0, nil,
-            &runningSize,
+            &size,
             &isRunning
         )
-        guard runningStatus == noErr else { return false }
+        guard status == noErr else { return false }
         return isRunning != 0
     }
 }

--- a/Notchy/MicrophoneActivityMonitor.swift
+++ b/Notchy/MicrophoneActivityMonitor.swift
@@ -1,0 +1,39 @@
+import Foundation
+import CoreAudio
+
+enum MicrophoneActivityMonitor {
+    static var isInputDeviceActive: Bool {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var defaultAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let defaultStatus = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultAddress,
+            0, nil,
+            &size,
+            &deviceID
+        )
+        guard defaultStatus == noErr, deviceID != 0 else { return false }
+
+        var isRunning: UInt32 = 0
+        var runningSize = UInt32(MemoryLayout<UInt32>.size)
+        var runningAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let runningStatus = AudioObjectGetPropertyData(
+            deviceID,
+            &runningAddress,
+            0, nil,
+            &runningSize,
+            &isRunning
+        )
+        guard runningStatus == noErr else { return false }
+        return isRunning != 0
+    }
+}

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -17,6 +17,9 @@ class NotchWindow: NSPanel {
     /// When the panel is visible, the notch stays in hover-grown size.
     var isPanelVisible: (() -> Bool)?
 
+    /// The screen this notch window targets (nil = built-in display).
+    private let targetScreenID: CGDirectDisplayID?
+
     /// Detected notch dimensions (updated on screen change).
     private var notchWidth: CGFloat = 180
     private var notchHeight: CGFloat = 37
@@ -36,7 +39,12 @@ class NotchWindow: NSPanel {
     /// SwiftUI content overlay shown inside the pill when expanded
     private var pillContentHost: NSHostingView<NotchPillContent>?
 
-    init(onHover: @escaping () -> Void) {
+    /// Creates a NotchWindow for the given screen.
+    /// - Parameters:
+    ///   - screenID: The CGDirectDisplayID to target, or nil for the built-in display.
+    ///   - onHover: Called when the mouse enters the trigger zone.
+    init(screenID: CGDirectDisplayID? = nil, onHover: @escaping () -> Void) {
+        self.targetScreenID = screenID
         self.onHover = onHover
 
         super.init(
@@ -174,7 +182,7 @@ class NotchWindow: NSPanel {
 
     private func expandWithBounce() {
         isExpanded = true
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
 
         let targetWidth: CGFloat = notchWidth + 80
@@ -228,7 +236,7 @@ class NotchWindow: NSPanel {
             self.pillContentHost?.animator().alphaValue = 0
         }
 
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
 
         var targetFrame = NSRect(
@@ -281,7 +289,7 @@ class NotchWindow: NSPanel {
     // MARK: - Notch size detection
 
     private func detectNotchSize() {
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
 
         if #available(macOS 12.0, *),
            let left = screen.auxiliaryTopLeftArea,
@@ -300,7 +308,7 @@ class NotchWindow: NSPanel {
     // MARK: - Positioning
 
     private func positionAtNotch() {
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let x = screenFrame.midX - notchWidth / 2
         let y = screenFrame.maxY - notchHeight
@@ -325,7 +333,7 @@ class NotchWindow: NSPanel {
         let mouseLocation = NSEvent.mouseLocation
 
         // Check the notch area itself
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let effectiveWidth = isExpanded ? notchWidth + 80 : notchWidth
         let notchRect = NSRect(
@@ -407,7 +415,7 @@ class NotchWindow: NSPanel {
         pillView.isHovered = false
         pillView.earProtrusion = 0
         pillContentHost?.rootView = NotchPillContent(isHovering: false)
-        guard let screen = NSScreen.builtIn else { return }
+        guard let screen = resolvedScreen else { return }
         let screenFrame = screen.frame
         let baseWidth = isExpanded ? notchWidth + 80 : notchWidth
         let targetFrame = NSRect(
@@ -432,6 +440,17 @@ class NotchWindow: NSPanel {
         }
     }
 
+    /// Resolves the screen this notch window targets.
+    private var resolvedScreen: NSScreen? {
+        if let id = targetScreenID {
+            return NSScreen.screens.first { screen in
+                let screenID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
+                return screenID == id
+            }
+        }
+        return NSScreen.builtIn
+    }
+
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 }
@@ -439,12 +458,19 @@ class NotchWindow: NSPanel {
 // MARK: - NSScreen helper
 
 extension NSScreen {
+    /// The CGDirectDisplayID for this screen.
+    var displayID: CGDirectDisplayID {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
+    }
+
     /// Returns the built-in display (the one with the notch), or the main screen as fallback.
     static var builtIn: NSScreen? {
-        screens.first { screen in
-            let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
-            return CGDisplayIsBuiltin(id) != 0
-        } ?? main
+        screens.first { CGDisplayIsBuiltin($0.displayID) != 0 } ?? main
+    }
+
+    /// Returns all external (non-built-in) screens.
+    static var externalScreens: [NSScreen] {
+        screens.filter { CGDisplayIsBuiltin($0.displayID) == 0 }
     }
 }
 

--- a/Notchy/NotchWindow.swift
+++ b/Notchy/NotchWindow.swift
@@ -20,6 +20,20 @@ class NotchWindow: NSPanel {
     /// The screen this notch window targets (nil = built-in display).
     private let targetScreenID: CGDirectDisplayID?
 
+    /// True for external displays — pill stays hidden during routine activity
+    /// (no real notch to cover, so a black pill would just look like a stray box)
+    /// but becomes visible when a session needs the user's attention.
+    private var isExternal: Bool { targetScreenID != nil }
+
+    /// External screens only show the pill for these states — idle keeps
+    /// the window invisible.
+    private static let externalAttentionStates: Set<NotchDisplayState> = [
+        .working,
+        .waitingForInput,
+        .taskCompleted,
+        .interrupted,
+    ]
+
     /// Detected notch dimensions (updated on screen change).
     private var notchWidth: CGFloat = 180
     private var notchHeight: CGFloat = 37
@@ -66,11 +80,14 @@ class NotchWindow: NSPanel {
         ignoresMouseEvents = false
         alphaValue = 1
 
-        // Set up the pill view (always visible)
+        // Set up the pill view. Built-in: always visible (covers the real notch).
+        // External: created but invisible — only revealed when a session needs
+        // attention (see updateExpansionState / collapse).
         if let cv = contentView {
+            let initialAlpha: CGFloat = isExternal ? 0 : 1
             pillView.frame = cv.bounds
             pillView.autoresizingMask = [.width, .height]
-            pillView.alphaValue = 1
+            pillView.alphaValue = initialAlpha
             cv.addSubview(pillView)
             cv.wantsLayer = true
             cv.layer?.masksToBounds = false
@@ -79,7 +96,7 @@ class NotchWindow: NSPanel {
             let hostView = NSHostingView(rootView: NotchPillContent())
             hostView.frame = cv.bounds
             hostView.autoresizingMask = [.width, .height]
-            hostView.alphaValue = 1
+            hostView.alphaValue = initialAlpha
             hostView.wantsLayer = true
             hostView.layer?.backgroundColor = .clear
             cv.addSubview(hostView)
@@ -155,7 +172,16 @@ class NotchWindow: NSPanel {
     }
 
     private func updateExpansionState() {
-        let shouldExpand = NotchDisplayState.current != .idle
+        let state = NotchDisplayState.current
+        let shouldExpand: Bool
+        if isExternal {
+            // External screens stay hidden during routine activity — only
+            // attention states (waitingForInput/taskCompleted/interrupted)
+            // make the pill visible.
+            shouldExpand = Self.externalAttentionStates.contains(state)
+        } else {
+            shouldExpand = state != .idle
+        }
 
         if shouldExpand && !isExpanded {
             collapseDebounceTimer?.invalidate()
@@ -169,7 +195,11 @@ class NotchWindow: NSPanel {
                 guard let self else { return }
                 self.collapseDebounceTimer = nil
                 // Re-check — state may have changed during the debounce
-                if NotchDisplayState.current == .idle && self.isExpanded {
+                guard self.isExpanded else { return }
+                let stillShouldExpand: Bool = self.isExternal
+                    ? Self.externalAttentionStates.contains(NotchDisplayState.current)
+                    : NotchDisplayState.current != .idle
+                if !stillShouldExpand {
                     self.collapse()
                 }
             }
@@ -230,10 +260,14 @@ class NotchWindow: NSPanel {
     private func collapse() {
         isExpanded = false
 
-        // Fade out the status content but keep the pill visible
+        // Fade out the status content. On external screens also fade the pill
+        // itself, since there's no real notch to keep visible underneath.
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.15
             self.pillContentHost?.animator().alphaValue = 0
+            if self.isExternal {
+                self.pillView.animator().alphaValue = 0
+            }
         }
 
         guard let screen = resolvedScreen else { return }
@@ -270,8 +304,11 @@ class NotchWindow: NSPanel {
                     display: true
                 )
                 if t >= 1.0 {
-                    // Show the idle content once collapse animation finishes
-                    self.pillContentHost?.alphaValue = 1
+                    // On built-in, show the idle content once collapse finishes.
+                    // External screens stay fully hidden between attention events.
+                    if !self.isExternal {
+                        self.pillContentHost?.alphaValue = 1
+                    }
                 }
             }
             return t < 1.0
@@ -582,9 +619,10 @@ enum NotchDisplayState: Equatable {
     case idle
     case working
     case waitingForInput
+    case interrupted
     case taskCompleted
 
-    /// Hierarchy: .taskCompleted (always shown) > .waitingForInput > .working > .idle
+    /// Hierarchy: .taskCompleted > .waitingForInput > .interrupted > .working > .idle
     static var current: NotchDisplayState {
         guard SettingsManager.shared.claudeIntegrationEnabled else { return .idle }
         let sessions = SessionStore.shared.sessions
@@ -593,6 +631,9 @@ enum NotchDisplayState: Equatable {
         }
         if sessions.contains(where: { $0.terminalStatus == .waitingForInput }) {
             return .waitingForInput
+        }
+        if sessions.contains(where: { $0.terminalStatus == .interrupted }) {
+            return .interrupted
         }
         if sessions.contains(where: { $0.terminalStatus == .working }) {
             return .working
@@ -637,6 +678,11 @@ struct NotchPillContent: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 16, weight: .bold))
                             .foregroundColor(.yellow)
+                            .transition(.scale.combined(with: .opacity))
+                    case .interrupted:
+                        Image(systemName: "exclamationmark.octagon.fill")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundColor(.red)
                             .transition(.scale.combined(with: .opacity))
                     case .working:
                         SpinnerView()

--- a/Notchy/PanelContentView.swift
+++ b/Notchy/PanelContentView.swift
@@ -35,6 +35,7 @@ struct PanelContentView: View {
     var onClose: () -> Void
     var onToggleExpand: (() -> Void)?
     @State private var showRestoreConfirmation = false
+    @State private var showConductor = false
 
     private var foregroundOpacity: Double {
         sessionStore.isWindowFocused ? 1.0 : 0.6
@@ -82,8 +83,11 @@ struct PanelContentView: View {
                             .frame(height: 200)
                     )
 
+                ProjectGroupPill(sessionStore: sessionStore, foregroundOpacity: foregroundOpacity)
 
-                SessionTabBar(sessionStore: sessionStore)
+                SessionTabBar(sessionStore: sessionStore, onTabSelected: { _ in
+                    showConductor = false
+                })
 
                 Rectangle()
                     .foregroundColor(.clear)
@@ -95,6 +99,20 @@ struct PanelContentView: View {
                         })
                             .frame(height: 200)
                     )
+
+                ZStack {
+                    Button(action: { showConductor.toggle() }) {
+                        Image(systemName: showConductor ? "rectangle.stack.fill" : "rectangle.stack")
+                            .font(.system(size: 12, weight: .medium))
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.white.opacity(foregroundOpacity))
+                    .help(showConductor ? "Hide Conductor" : "Show Conductor (all sessions)")
+                }
+                .padding(.leading, -4)
+                .padding(.trailing, -4)
 
                 ZStack {
                     Button(action: { sessionStore.createQuickSession() }) {
@@ -184,8 +202,11 @@ struct PanelContentView: View {
             if sessionStore.isTerminalExpanded {
                 Divider()
 
-                // Terminal area
-                if let session = sessionStore.activeSession {
+                if showConductor {
+                    ConductorView(sessionStore: sessionStore, onSessionSelected: { _ in
+                        showConductor = false
+                    })
+                } else if let session = sessionStore.activeSession {
                     if session.hasStarted {
                         TerminalSessionView(
                             sessionId: session.id,
@@ -221,6 +242,31 @@ struct PanelContentView: View {
                     placeholderView("No Xcode projects detected.\nClick + to create a new session.")
                 } else {
                     placeholderView("Select a project to begin")
+                }
+
+                if !showConductor,
+                   let session = sessionStore.activeSession,
+                   let lastRequest = session.lastRequest,
+                   !lastRequest.isEmpty {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.up.message")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(.white.opacity(0.45))
+                        Text("Last request:")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.white.opacity(0.45))
+                        Text(lastRequest)
+                            .font(.system(size: 10))
+                            .foregroundColor(.white.opacity(0.7))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Spacer(minLength: 8)
+                        UsageInlineBadge(monitor: UsageMonitor.shared)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(Color(nsColor: NSColor(white: 0.13, alpha: 1.0)).opacity(chromeBackgroundOpacity))
+                    .help(lastRequest)
                 }
             }
         }
@@ -270,5 +316,41 @@ struct PanelContentView: View {
                     .multilineTextAlignment(.center)
                     .opacity(0)
             }
+    }
+}
+
+/// Compact Claude Code usage readout shown at the right edge of the
+/// last-request bar — one colored percentage per usage window.
+private struct UsageInlineBadge: View {
+    @Bindable var monitor: UsageMonitor
+
+    private func color(for percent: Int) -> Color {
+        if percent >= 90 { return .red }
+        if percent >= 70 { return .orange }
+        return .green
+    }
+
+    var body: some View {
+        if let windows = monitor.snapshot?.windows, !windows.isEmpty {
+            HStack(spacing: 8) {
+                Image(systemName: "gauge.with.dots.needle.50percent")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.4))
+                ForEach(windows) { window in
+                    HStack(spacing: 3) {
+                        Text(window.label)
+                            .font(.system(size: 9))
+                            .foregroundColor(.white.opacity(0.45))
+                            .lineLimit(1)
+                        Text("\(window.percent)%")
+                            .font(.system(size: 10, weight: .semibold).monospacedDigit())
+                            .foregroundColor(color(for: window.percent).opacity(0.95))
+                    }
+                    .fixedSize()
+                }
+            }
+            .help(windows.map { "\($0.label): \($0.percent)%" + ($0.resets.map { " (resets \($0))" } ?? "") }
+                .joined(separator: "\n"))
+        }
     }
 }

--- a/Notchy/ProjectGroup.swift
+++ b/Notchy/ProjectGroup.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A named collection of `TerminalSession`s, usually corresponding to a git repository.
+///
+/// `rootPath` is the absolute path to the group's anchor — typically a git
+/// `--show-toplevel` result. It's the key we match newly-created sessions
+/// against to auto-assign them. nil means "no shared root" (a manually-created
+/// group of unrelated tabs, or the catch-all for non-git sessions).
+///
+/// `name` is independent of `rootPath` so the user can rename groups freely
+/// without losing the auto-assignment behavior.
+struct ProjectGroup: Identifiable, Equatable, Codable {
+    let id: UUID
+    var name: String
+    var rootPath: String?
+    /// The `ClaudeAccount` this project's terminals run under, via
+    /// `CLAUDE_CONFIG_DIR`. nil = the default `~/.claude` login. Optional so old
+    /// persisted groups (which predate this field) decode cleanly to nil.
+    var accountId: UUID?
+
+    init(id: UUID = UUID(), name: String, rootPath: String? = nil, accountId: UUID? = nil) {
+        self.id = id
+        self.name = name
+        self.rootPath = rootPath
+        self.accountId = accountId
+    }
+}

--- a/Notchy/ProjectGroupPill.swift
+++ b/Notchy/ProjectGroupPill.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// Leading pill in the panel chrome that shows the active `ProjectGroup` and
+/// opens a menu listing all groups + project-level actions.
+struct ProjectGroupPill: View {
+    @Bindable var sessionStore: SessionStore
+    var foregroundOpacity: Double = 1.0
+
+    @State private var renameText: String = ""
+    @State private var showRenameDialog = false
+    @State private var renameTargetId: UUID?
+    @State private var newProjectText: String = ""
+    @State private var showNewProjectDialog = false
+    @State private var showAccountRestartDialog = false
+    /// Account choice awaiting restart confirmation. nil means "Default" —
+    /// `showAccountRestartDialog` alone tracks whether a switch is pending.
+    @State private var pendingAccountId: UUID?
+    @State private var pendingAccountGroupId: UUID?
+
+    private var activeGroup: ProjectGroup? {
+        guard let id = sessionStore.activeProjectGroupId else { return nil }
+        return sessionStore.projectGroups.first { $0.id == id }
+    }
+
+    private var displayName: String {
+        activeGroup?.name ?? "Project"
+    }
+
+    private var canDeleteActive: Bool {
+        guard let id = sessionStore.activeProjectGroupId else { return false }
+        return sessionStore.sessions.allSatisfy { $0.groupId != id }
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(sessionStore.projectGroups) { group in
+                Button {
+                    sessionStore.selectGroup(group.id)
+                } label: {
+                    let title = sessionStore.groupNeedsAttention(group.id)
+                        ? "\(group.name) !"
+                        : group.name
+                    if group.id == sessionStore.activeProjectGroupId {
+                        Label(title, systemImage: "checkmark")
+                    } else {
+                        Text(title)
+                    }
+                }
+            }
+            if !sessionStore.projectGroups.isEmpty {
+                Divider()
+            }
+            Button("New Project…") {
+                newProjectText = ""
+                showNewProjectDialog = true
+            }
+            if let active = activeGroup {
+                Button("Rename Project…") {
+                    renameText = active.name
+                    renameTargetId = active.id
+                    showRenameDialog = true
+                }
+                Menu("Account") {
+                    Button {
+                        requestAccountChange(nil, group: active)
+                    } label: {
+                        if active.accountId == nil {
+                            Label("Default", systemImage: "checkmark")
+                        } else {
+                            Text("Default")
+                        }
+                    }
+                    if !SettingsManager.shared.accounts.isEmpty { Divider() }
+                    ForEach(SettingsManager.shared.accounts) { account in
+                        Button {
+                            requestAccountChange(account.id, group: active)
+                        } label: {
+                            if active.accountId == account.id {
+                                Label(account.name, systemImage: "checkmark")
+                            } else {
+                                Text(account.name)
+                            }
+                        }
+                    }
+                }
+                Button("Delete Project", role: .destructive) {
+                    sessionStore.deleteGroup(active.id)
+                }
+                .disabled(!canDeleteActive)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "folder")
+                    .font(.system(size: 10, weight: .medium))
+                Text(displayName)
+                    .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .opacity(0.6)
+            }
+            .foregroundColor(.white.opacity(foregroundOpacity))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.white.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color.white.opacity(0.1), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .alert("Rename Project", isPresented: $showRenameDialog) {
+            TextField("Project name", text: $renameText)
+            Button("Rename") {
+                if let id = renameTargetId, !renameText.isEmpty {
+                    sessionStore.renameGroup(id, to: renameText)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .alert("New Project", isPresented: $showNewProjectDialog) {
+            TextField("Project name", text: $newProjectText)
+            Button("Create") {
+                let trimmed = newProjectText.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { return }
+                let id = sessionStore.createGroup(named: trimmed)
+                sessionStore.selectGroup(id)
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .alert("Switch Account", isPresented: $showAccountRestartDialog) {
+            Button("Restart Sessions", role: .destructive) {
+                if let groupId = pendingAccountGroupId {
+                    sessionStore.setAccount(pendingAccountId, forGroup: groupId)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(accountRestartMessage)
+        }
+        .onChange(of: showRenameDialog) { updateIsShowingDialog() }
+        .onChange(of: showNewProjectDialog) { updateIsShowingDialog() }
+        .onChange(of: showAccountRestartDialog) { updateIsShowingDialog() }
+    }
+
+    private func updateIsShowingDialog() {
+        sessionStore.isShowingDialog = showRenameDialog || showNewProjectDialog || showAccountRestartDialog
+    }
+
+    /// Sessions in the group whose terminals are live and would be killed by an
+    /// account switch.
+    private func runningSessions(inGroup groupId: UUID) -> [TerminalSession] {
+        sessionStore.sessions.filter { $0.groupId == groupId && $0.hasStarted }
+    }
+
+    /// Applies the account immediately when nothing is running; otherwise asks
+    /// for confirmation first, since switching restarts the group's terminals.
+    private func requestAccountChange(_ accountId: UUID?, group: ProjectGroup) {
+        guard group.accountId != accountId else { return }
+        if runningSessions(inGroup: group.id).isEmpty {
+            sessionStore.setAccount(accountId, forGroup: group.id)
+        } else {
+            pendingAccountId = accountId
+            pendingAccountGroupId = group.id
+            showAccountRestartDialog = true
+        }
+    }
+
+    private var accountRestartMessage: String {
+        guard let groupId = pendingAccountGroupId else { return "" }
+        let running = runningSessions(inGroup: groupId)
+        let count = running.count == 1 ? "1 running session" : "\(running.count) running sessions"
+        let base = "Switching accounts will restart \(count) in this project."
+        if running.contains(where: { $0.terminalStatus == .working }) {
+            return base + " Claude is currently working in at least one of them — that work will be interrupted."
+        }
+        return base
+    }
+}

--- a/Notchy/SessionStore.swift
+++ b/Notchy/SessionStore.swift
@@ -15,6 +15,21 @@ class SessionStore {
 
     var sessions: [TerminalSession] = []
     var activeSessionId: UUID?
+
+    /// All known project groups. Auto-populated as new git roots are discovered;
+    /// also editable by the user (rename, delete-when-empty, new).
+    var projectGroups: [ProjectGroup] = []
+    /// Group whose tabs are currently visible in the tab bar. nil only briefly
+    /// before the first group exists.
+    var activeProjectGroupId: UUID? {
+        didSet {
+            if let id = activeProjectGroupId {
+                UserDefaults.standard.set(id.uuidString, forKey: Self.activeGroupKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.activeGroupKey)
+            }
+        }
+    }
     var isPinned: Bool = {
         if UserDefaults.standard.object(forKey: "isPinned") == nil { return true }
         return UserDefaults.standard.bool(forKey: "isPinned")
@@ -28,6 +43,11 @@ class SessionStore {
     var isWindowFocused = true
     var isShowingDialog = false
     var hasCompletedInitialDetection = false
+
+    /// Non-nil while the user is mid drag-reorder of a tab. Lifted out of
+    /// `SessionTabBar` so other views observing `sessions` (notably the
+    /// Conductor) can freeze their layout while the array churns.
+    var draggedSessionId: UUID?
 
     /// The most recent checkpoint for the active session, used to show the undo button
     var lastCheckpoint: Checkpoint?
@@ -74,13 +94,55 @@ class SessionStore {
 
     private static let sessionsKey = "persistedSessions"
     private static let activeSessionKey = "activeSessionId"
+    private static let groupsKey = "projectGroups"
+    private static let activeGroupKey = "activeProjectGroupId"
+
+    /// Cache of resolved git roots keyed by working directory. Avoids re-spawning
+    /// `git` for repeated lookups in the same dir (e.g. multiple sessions sharing it).
+    private var gitRootCache: [String: String?] = [:]
 
     init() {
+        restoreGroups()
         restoreSessions()
+        backfillMissingGroupIds()
+        restoreActiveGroup()
         updatePollingTimer()
     }
 
     // MARK: - Session Persistence
+
+    private func restoreGroups() {
+        guard let data = UserDefaults.standard.data(forKey: Self.groupsKey),
+              let decoded = try? JSONDecoder().decode([ProjectGroup].self, from: data) else { return }
+        projectGroups = decoded
+    }
+
+    private func restoreActiveGroup() {
+        if let saved = UserDefaults.standard.string(forKey: Self.activeGroupKey),
+           let uuid = UUID(uuidString: saved),
+           projectGroups.contains(where: { $0.id == uuid }) {
+            activeProjectGroupId = uuid
+        } else {
+            // Follow the active session if we have one, otherwise the first group.
+            activeProjectGroupId = activeSession?.groupId ?? projectGroups.first?.id
+        }
+    }
+
+    /// Resolves git roots for any session whose `groupId` is nil (pre-feature
+    /// data) and finds-or-creates the matching `ProjectGroup`. Runs synchronously
+    /// at launch — git rev-parse is cheap and this is a one-time pass per session.
+    private func backfillMissingGroupIds() {
+        var changed = false
+        for i in sessions.indices where sessions[i].groupId == nil {
+            let groupId = findOrCreateGroup(for: sessions[i])
+            sessions[i].groupId = groupId
+            changed = true
+        }
+        if changed {
+            persistGroups()
+            persistSessions()
+        }
+    }
 
     private func restoreSessions() {
         guard let data = UserDefaults.standard.data(forKey: Self.sessionsKey),
@@ -98,11 +160,50 @@ class SessionStore {
         for i in sessions.indices {
             sessions[i].hasStarted = true
             sessions[i].hasBeenSelected = true
+            // One-time cleanup: collapse adjacent exchanges with identical
+            // prompts that were captured by an earlier scraper-flicker bug.
+            // Prefer keeping the entry that has a generated summary, the
+            // verified flag, or a completion timestamp.
+            sessions[i].exchanges = collapseAdjacentDuplicates(sessions[i].exchanges)
         }
+        persistSessions()
     }
 
+    private func collapseAdjacentDuplicates(_ exchanges: [TaskExchange]) -> [TaskExchange] {
+        var result: [TaskExchange] = []
+        for exchange in exchanges {
+            if let last = result.last, last.prompt == exchange.prompt {
+                result[result.count - 1] = pickBetter(last, exchange)
+            } else {
+                result.append(exchange)
+            }
+        }
+        return result
+    }
+
+    private func pickBetter(_ a: TaskExchange, _ b: TaskExchange) -> TaskExchange {
+        let aScore = (a.verified ? 4 : 0) + (a.summary != nil ? 2 : 0) + (a.completedAt != nil ? 1 : 0)
+        let bScore = (b.verified ? 4 : 0) + (b.summary != nil ? 2 : 0) + (b.completedAt != nil ? 1 : 0)
+        return bScore > aScore ? b : a
+    }
+
+    /// Cap on persisted exchanges per session — keeps UserDefaults blob small
+    /// while still showing the user a meaningful history on next launch.
+    private static let persistedExchangeLimit = 50
+
     private func persistSessions() {
-        let persisted = sessions.map { PersistedSession(id: $0.id, projectName: $0.projectName, projectPath: $0.projectPath, workingDirectory: $0.workingDirectory) }
+        let persisted = sessions.map { session -> PersistedSession in
+            let trimmed = Array(session.exchanges.suffix(Self.persistedExchangeLimit))
+            return PersistedSession(
+                id: session.id,
+                projectName: session.projectName,
+                projectPath: session.projectPath,
+                workingDirectory: session.workingDirectory,
+                exchanges: trimmed,
+                pendingPromptText: session.pendingPromptText,
+                groupId: session.groupId
+            )
+        }
         if let data = try? JSONEncoder().encode(persisted) {
             UserDefaults.standard.set(data, forKey: Self.sessionsKey)
         }
@@ -110,6 +211,169 @@ class SessionStore {
             UserDefaults.standard.set(activeId.uuidString, forKey: Self.activeSessionKey)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.activeSessionKey)
+        }
+    }
+
+    private func persistGroups() {
+        if let data = try? JSONEncoder().encode(projectGroups) {
+            UserDefaults.standard.set(data, forKey: Self.groupsKey)
+        }
+    }
+
+    // MARK: - Project Groups
+
+    /// Shells out to `git -C <dir> rev-parse --show-toplevel` to find the
+    /// repo root. Returns nil if not in a git repo or the command fails.
+    /// Memoized per directory to avoid repeated work.
+    private func gitRoot(for directory: String) -> String? {
+        if let cached = gitRootCache[directory] {
+            return cached
+        }
+        let result: String? = {
+            guard FileManager.default.fileExists(atPath: directory) else { return nil }
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["git", "-C", directory, "rev-parse", "--show-toplevel"]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = Pipe()
+            do {
+                try process.run()
+                process.waitUntilExit()
+            } catch {
+                return nil
+            }
+            guard process.terminationStatus == 0,
+                  let data = try? pipe.fileHandleForReading.readToEnd(),
+                  let out = String(data: data, encoding: .utf8) else { return nil }
+            let trimmed = out.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }()
+        gitRootCache[directory] = result
+        return result
+    }
+
+    /// Find an existing group matching the session's git root, or create one.
+    /// Sessions without a git root all fall into a single "Other" sentinel group
+    /// (created lazily on first need).
+    private func findOrCreateGroup(for session: TerminalSession) -> UUID {
+        if let root = gitRoot(for: session.workingDirectory) {
+            if let existing = projectGroups.first(where: { $0.rootPath == root }) {
+                return existing.id
+            }
+            let name = (root as NSString).lastPathComponent
+            let group = ProjectGroup(name: name.isEmpty ? "Project" : name, rootPath: root)
+            projectGroups.append(group)
+            return group.id
+        }
+        if let other = projectGroups.first(where: { $0.rootPath == nil && $0.name == "Other" }) {
+            return other.id
+        }
+        let other = ProjectGroup(name: "Other", rootPath: nil)
+        projectGroups.append(other)
+        return other.id
+    }
+
+    /// True when any session in the group is blocked waiting for user input —
+    /// drives the "!" marker in the project switcher menu.
+    func groupNeedsAttention(_ id: UUID) -> Bool {
+        sessions.contains { $0.groupId == id && $0.terminalStatus == .waitingForInput }
+    }
+
+    /// Sessions belonging to the currently-active project group. Drives the tab bar.
+    var sessionsInActiveGroup: [TerminalSession] {
+        guard let activeId = activeProjectGroupId else { return sessions }
+        return sessions.filter { $0.groupId == activeId }
+    }
+
+    /// Switch which group's tabs are visible. If the previously-active session
+    /// isn't in the new group, fall back to that group's first session (or nil).
+    func selectGroup(_ id: UUID) {
+        activeProjectGroupId = id
+        if let active = activeSession, active.groupId == id { return }
+        if let first = sessions.first(where: { $0.groupId == id }) {
+            activeSessionId = first.id
+        }
+        persistSessions()
+    }
+
+    /// Create a new empty group and make it active. Returns the new group's ID.
+    @discardableResult
+    func createGroup(named name: String) -> UUID {
+        let group = ProjectGroup(name: name.isEmpty ? "Untitled" : name, rootPath: nil)
+        projectGroups.append(group)
+        persistGroups()
+        return group.id
+    }
+
+    func renameGroup(_ id: UUID, to newName: String) {
+        guard let index = projectGroups.firstIndex(where: { $0.id == id }) else { return }
+        let trimmed = newName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        projectGroups[index].name = trimmed
+        persistGroups()
+    }
+
+    /// Assign (or clear, with nil) the Claude account a group's terminals run
+    /// under, then restart the group's running sessions so their new shells
+    /// pick up the account's `CLAUDE_CONFIG_DIR`.
+    func setAccount(_ accountId: UUID?, forGroup groupId: UUID) {
+        guard let index = projectGroups.firstIndex(where: { $0.id == groupId }),
+              projectGroups[index].accountId != accountId else { return }
+        projectGroups[index].accountId = accountId
+        persistGroups()
+        for session in sessions where session.groupId == groupId && session.hasStarted {
+            restartSession(session.id)
+        }
+    }
+
+    /// Delete a group. Only succeeds if the group has no member sessions —
+    /// otherwise the caller should reassign or close those sessions first.
+    @discardableResult
+    func deleteGroup(_ id: UUID) -> Bool {
+        guard sessions.allSatisfy({ $0.groupId != id }) else { return false }
+        projectGroups.removeAll { $0.id == id }
+        if activeProjectGroupId == id {
+            activeProjectGroupId = projectGroups.first?.id
+            if let firstId = activeProjectGroupId,
+               let first = sessions.first(where: { $0.groupId == firstId }) {
+                activeSessionId = first.id
+            }
+        }
+        persistGroups()
+        return true
+    }
+
+    /// Move a session into a different group. Switches the active group to match
+    /// so the user sees where the tab went.
+    func moveSession(_ sessionId: UUID, toGroup groupId: UUID) {
+        guard let sIdx = sessions.firstIndex(where: { $0.id == sessionId }),
+              projectGroups.contains(where: { $0.id == groupId }) else { return }
+        sessions[sIdx].groupId = groupId
+        activeProjectGroupId = groupId
+        activeSessionId = sessionId
+        persistSessions()
+    }
+
+    /// Force-write the latest in-memory state to disk. Called from
+    /// applicationWillTerminate so a draft mid-keystroke survives Cmd+Q
+    /// (updatePendingPromptText doesn't persist on every keystroke).
+    func flushPersistence() {
+        persistSessions()
+    }
+
+    /// Eagerly boot the terminal process for every restored session so each tab
+    /// is already cd'd into its saved directory (and running `claude` for project
+    /// tabs with a CLAUDE.md) by the time the user reveals the panel. Without this
+    /// only the active tab's `TerminalSessionView` triggers terminal creation, so
+    /// inactive tabs sit cold until clicked.
+    func warmUpRestoredSessions() {
+        for session in sessions where session.hasStarted {
+            _ = TerminalManager.shared.terminal(
+                for: session.id,
+                workingDirectory: session.workingDirectory,
+                launchClaude: session.projectPath != nil
+            )
         }
     }
 
@@ -182,17 +446,39 @@ class SessionStore {
         }
 
 
+        var groupsChanged = false
         for project in projects {
-            guard !sessions.contains(where: { $0.projectName == project.name }),
-                  dismissedProjects[project.name] == nil else { continue }
-            let session = TerminalSession(
+            if let index = sessions.firstIndex(where: { $0.projectName == project.name }) {
+                // Heal sessions created while AppleScript reported no path
+                // (`missing value`) — adopt the real path once detection has it.
+                if !project.path.isEmpty, sessions[index].projectPath != project.path {
+                    sessions[index].projectPath = project.path
+                    // Only retarget the directory if no shell is running yet;
+                    // a live shell's cwd is tracked via OSC 7 instead.
+                    if !sessions[index].hasStarted {
+                        sessions[index].workingDirectory = project.directoryPath
+                    }
+                }
+                continue
+            }
+            guard dismissedProjects[project.name] == nil else { continue }
+            var session = TerminalSession(
                 projectName: project.name,
                 projectPath: project.path,
                 workingDirectory: project.directoryPath,
                 started: false
             )
+            let groupsBefore = projectGroups.count
+            session.groupId = findOrCreateGroup(for: session)
+            if projectGroups.count != groupsBefore { groupsChanged = true }
             sessions.append(session)
         }
+        // First session ever — make sure something is the active group so the
+        // tab bar isn't empty.
+        if activeProjectGroupId == nil {
+            activeProjectGroupId = projectGroups.first?.id
+        }
+        if groupsChanged { persistGroups() }
         persistSessions()
     }
 
@@ -206,6 +492,9 @@ class SessionStore {
             guard !sessions[index].hasBeenSelected else { return false }
             sessions[index].hasBeenSelected = true
             activeSessionId = sessions[index].id
+            if let gid = sessions[index].groupId, gid != activeProjectGroupId {
+                activeProjectGroupId = gid
+            }
             startSessionIfNeeded(sessions[index].id)
             return true
         }
@@ -218,6 +507,12 @@ class SessionStore {
         if let index = sessions.firstIndex(where: { $0.id == id }) {
             sessions[index].hasBeenSelected = true
             let session = sessions[index]
+            // Follow the session into its group so the tab bar stays in sync —
+            // otherwise selecting a session from the status menu / Conductor
+            // leaves the visible tab bar showing a different group's tabs.
+            if let gid = session.groupId, gid != activeProjectGroupId {
+                activeProjectGroupId = gid
+            }
             // Auto-start if it's a plain terminal (no project) or the project is open in Xcode
             if session.projectPath == nil || activeXcodeProjects.contains(session.projectName) {
                 startSessionIfNeeded(id)
@@ -239,14 +534,24 @@ class SessionStore {
         }
     }
 
-    /// "+" button: creates a plain terminal session with no project association
+    /// "+" button: creates a plain terminal session in the currently-active group
+    /// (so the new tab shows up immediately in the visible tab bar).
     func createQuickSession() {
-        let session = TerminalSession(
+        var session = TerminalSession(
             projectName: "Terminal",
             started: true
         )
+        let groupsBefore = projectGroups.count
+        if let activeId = activeProjectGroupId,
+           projectGroups.contains(where: { $0.id == activeId }) {
+            session.groupId = activeId
+        } else {
+            session.groupId = findOrCreateGroup(for: session)
+        }
+        if projectGroups.count != groupsBefore { persistGroups() }
         sessions.append(session)
         activeSessionId = session.id
+        if activeProjectGroupId == nil { activeProjectGroupId = session.groupId }
         persistSessions()
     }
 
@@ -256,15 +561,184 @@ class SessionStore {
         persistSessions()
     }
 
+    /// Update the in-progress prompt text the user is typing into Claude's input box.
+    func updatePendingPromptText(_ id: UUID, text: String?) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        // Never wipe an existing draft on a nil scrape. The input box transiently
+        // disappears between Enter and the spinner; status detection also flakes
+        // and can misclassify .waitingForInput as .idle. Either way, a transient
+        // nil must not destroy the draft before the .working transition can
+        // freeze it as lastRequest. The freeze itself clears pendingPromptText
+        // explicitly, and a fresh scrape with text will overwrite cleanly.
+        if text == nil {
+            return
+        }
+        if sessions[index].pendingPromptText != text {
+            sessions[index].pendingPromptText = text
+        }
+    }
+
+    /// Update the scraped activity line (Claude's spinner/status line while working).
+    func updateActivityLine(_ id: UUID, line: String?) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        if sessions[index].activityLine != line {
+            sessions[index].activityLine = line
+        }
+    }
+
+    /// Update the numbered choices Claude is currently presenting, the question
+    /// line above them, and any preview content (e.g. an edit's diff body) above
+    /// the question.
+    func updatePendingChoices(_ id: UUID, choices: [PromptChoice], question: String?, preview: String?) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        if sessions[index].pendingChoices != choices {
+            sessions[index].pendingChoices = choices
+        }
+        if sessions[index].pendingQuestion != question {
+            sessions[index].pendingQuestion = question
+        }
+        if sessions[index].pendingPromptPreview != preview {
+            sessions[index].pendingPromptPreview = preview
+        }
+    }
+
+    /// Send a numbered choice to the session's terminal as if the user pressed that digit.
+    func submitChoice(_ id: UUID, number: Int) {
+        TerminalManager.shared.sendInput(to: id, text: "\(number)")
+    }
+
+    /// Toggle the per-exchange "verified" checkbox in the Conductor.
+    func setExchangeVerified(_ sessionId: UUID, exchangeId: UUID, _ value: Bool) {
+        guard let sIdx = sessions.firstIndex(where: { $0.id == sessionId }),
+              let eIdx = sessions[sIdx].exchanges.firstIndex(where: { $0.id == exchangeId }) else { return }
+        sessions[sIdx].exchanges[eIdx].verified = value
+        persistSessions()
+    }
+
+    /// Kick off an async Claude API call to summarize the task associated with
+    /// `exchangeId`. Falls back silently if no API key is configured.
+    func requestSummary(for sessionId: UUID, exchangeId: UUID) {
+        print("[summary] requestSummary session=\(sessionId) exchange=\(exchangeId)")
+        guard let sIdx = sessions.firstIndex(where: { $0.id == sessionId }),
+              let eIdx = sessions[sIdx].exchanges.firstIndex(where: { $0.id == exchangeId }) else {
+            print("[summary] session/exchange not found, aborting")
+            return
+        }
+        guard !SettingsManager.shared.anthropicAPIKey.isEmpty else {
+            print("[summary] no Anthropic API key set — marking failed")
+            sessions[sIdx].exchanges[eIdx].summaryStatus = .failed
+            return
+        }
+        guard let snapshot = TerminalManager.shared.visibleText(for: sessionId), !snapshot.isEmpty else {
+            print("[summary] visibleText returned nil/empty — marking failed")
+            sessions[sIdx].exchanges[eIdx].summaryStatus = .failed
+            return
+        }
+        let prompt = sessions[sIdx].exchanges[eIdx].prompt
+        print("[summary] firing API call: snapshot=\(snapshot.count) chars, prompt=\"\(prompt)\"")
+        sessions[sIdx].exchanges[eIdx].summaryStatus = .generating
+        sessions[sIdx].exchanges[eIdx].summary = nil
+
+        Task { @MainActor in
+            do {
+                let summary = try await SummaryService.shared.summarize(
+                    terminalOutput: snapshot,
+                    lastRequest: prompt
+                )
+                print("[summary] success: \(summary.count) chars")
+                guard let s = self.sessions.firstIndex(where: { $0.id == sessionId }),
+                      let e = self.sessions[s].exchanges.firstIndex(where: { $0.id == exchangeId }) else { return }
+                self.sessions[s].exchanges[e].summary = summary
+                self.sessions[s].exchanges[e].summaryStatus = .ready
+                self.persistSessions()
+            } catch {
+                print("[summary] failed: \(error)")
+                guard let s = self.sessions.firstIndex(where: { $0.id == sessionId }),
+                      let e = self.sessions[s].exchanges.firstIndex(where: { $0.id == exchangeId }) else { return }
+                self.sessions[s].exchanges[e].summaryStatus = .failed
+                self.persistSessions()
+            }
+        }
+    }
+
     func updateTerminalStatus(_ id: UUID, status: TerminalStatus) {
         guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+
+        // Esc was pressed: mark the in-progress exchange as interrupted+dismissed
+        // and collapse the session straight to idle so the orange "Interrupted"
+        // pill doesn't linger. Bypasses the normal transition handlers below —
+        // we don't want sleep prevention, taskCompleted delays, or summarization
+        // firing for an interrupted run.
+        if status == .interrupted {
+            if let lastIdx = sessions[index].exchanges.indices.last,
+               sessions[index].exchanges[lastIdx].completedAt == nil {
+                sessions[index].exchanges[lastIdx].completedAt = Date()
+                sessions[index].exchanges[lastIdx].wasInterrupted = true
+                sessions[index].exchanges[lastIdx].verified = true
+                sessions[index].exchanges[lastIdx].summaryStatus = .none
+                persistSessions()
+            }
+            if sessions[index].terminalStatus != .idle {
+                sessions[index].terminalStatus = .idle
+                sessions[index].activityLine = nil
+                sessions[index].workingStartedAt = nil
+                updateSleepPrevention()
+            }
+            return
+        }
+
         if sessions[index].terminalStatus != status {
             let previous = sessions[index].terminalStatus
+            print("[status] \(sessions[index].projectName): \(previous) → \(status)")
             sessions[index].terminalStatus = status
+            if status != .working {
+                sessions[index].activityLine = nil
+            }
             updateSleepPrevention()
 
             if status == .working && previous != .working {
                 sessions[index].workingStartedAt = Date()
+                // User just submitted a request — freeze the pending text as a
+                // new exchange. Don't gate on previous == .waitingForInput:
+                // status can flicker through .idle between waitingForInput and
+                // working (input box disappears briefly before the spinner shows
+                // up). The presence of pending text is what signals a real
+                // submission.
+                if let pending = sessions[index].pendingPromptText, !pending.isEmpty {
+                    if pending.trimmingCharacters(in: .whitespaces).hasPrefix("/remote-control") {
+                        print("[status] skipped /remote-control exchange: \"\(pending)\"")
+                        sessions[index].pendingPromptText = nil
+                        return
+                    }
+                    // Dedupe: the prompt-input scraper can re-pick the same text
+                    // from a buffer echo after a flicker (e.g. .working → .idle →
+                    // .working between tool calls), which would otherwise append
+                    // a phantom duplicate exchange. If the latest exchange has the
+                    // identical prompt and is recent, treat the freeze as redundant.
+                    let isDuplicate = sessions[index].exchanges.last.map { last in
+                        last.prompt == pending && Date().timeIntervalSince(last.promptAt) < 120
+                    } ?? false
+                    if isDuplicate {
+                        print("[status] skipped duplicate exchange freeze: \"\(pending)\"")
+                        sessions[index].pendingPromptText = nil
+                    } else {
+                        print("[status] pushed new exchange: \"\(pending)\"")
+                        // If the previous exchange never got summarized (user submitted
+                        // a new prompt before .taskCompleted could fire), kick off its
+                        // summary now using the buffer state from just before the new
+                        // exchange starts altering it.
+                        if let lastIdx = sessions[index].exchanges.indices.last,
+                           sessions[index].exchanges[lastIdx].summaryStatus == .none,
+                           sessions[index].exchanges[lastIdx].summary == nil {
+                            let previousExchangeId = sessions[index].exchanges[lastIdx].id
+                            sessions[index].exchanges[lastIdx].completedAt = Date()
+                            requestSummary(for: id, exchangeId: previousExchangeId)
+                        }
+                        sessions[index].exchanges.append(TaskExchange(prompt: pending))
+                        sessions[index].pendingPromptText = nil
+                        persistSessions()
+                    }
+                }
             }
             if status == .waitingForInput && previous != .waitingForInput {
                 playSound(named: "waitingForInput")
@@ -275,19 +749,27 @@ class SessionStore {
             }
             else if status == .taskCompleted && previous != .taskCompleted {
                 playSound(named: "taskCompleted")
+                // A command just finished — refresh usage if our last snapshot is
+                // older than a minute. The 5-min timer is the fallback; this is
+                // the primary trigger so the header tracks real activity.
+                UsageMonitor.shared.refreshIfStale(maxAge: 60)
+                // Attach summary to the most recent exchange (the one that just finished).
+                if let lastIdx = sessions[index].exchanges.indices.last {
+                    let exchangeId = sessions[index].exchanges[lastIdx].id
+                    sessions[index].exchanges[lastIdx].completedAt = Date()
+                    persistSessions()
+                    if sessions[index].exchanges[lastIdx].summaryStatus == .none {
+                        requestSummary(for: id, exchangeId: exchangeId)
+                    }
+                }
             }
             else if status == .idle && previous == .working {
                 // Delay 3s before treating as "task completed" — Claude sometimes
                 // goes working → idle → working again briefly.
-                let workingStartedAt = sessions[index].workingStartedAt
                 Task { @MainActor in
                     try? await Task.sleep(for: .seconds(3))
                     guard let idx = self.sessions.firstIndex(where: { $0.id == id }),
                           self.sessions[idx].terminalStatus == .idle else { return }
-                    // Only trigger taskCompleted for tasks that ran >10s
-                    if let started = workingStartedAt, Date().timeIntervalSince(started) < 10 {
-                        return
-                    }
                     SessionStore.shared.updateTerminalStatus(id, status: .taskCompleted)
                     // Auto-clear taskCompleted after 3 seconds
                     try? await Task.sleep(for: .seconds(3))

--- a/Notchy/SessionStore.swift
+++ b/Notchy/SessionStore.swift
@@ -416,6 +416,11 @@ class SessionStore {
         sessions[index].generation += 1
     }
 
+    /// Persist the current session order (used after a drag-reorder)
+    func persistSessionOrder() {
+        persistSessions()
+    }
+
     func closeSession(_ id: UUID) {
         if let session = sessions.first(where: { $0.id == id }) {
             dismissedProjects[session.projectName] = false

--- a/Notchy/SessionStore.swift
+++ b/Notchy/SessionStore.swift
@@ -302,6 +302,7 @@ class SessionStore {
 
     private func playSound(named name: String) {
         guard SettingsManager.shared.soundsEnabled else { return }
+        if SettingsManager.shared.muteSoundsDuringCalls && MicrophoneActivityMonitor.isInputDeviceActive { return }
         let now = Date()
         guard now.timeIntervalSince(lastSoundPlayedAt) >= 1.0 else { return }
         guard let url = Bundle.main.url(forResource: name, withExtension: "mp3") else { return }

--- a/Notchy/SessionTabBar.swift
+++ b/Notchy/SessionTabBar.swift
@@ -3,26 +3,41 @@ import UniformTypeIdentifiers
 
 struct SessionTabBar: View {
     @Bindable var sessionStore: SessionStore
-    @State private var draggedSessionId: UUID?
+    var onTabSelected: ((UUID) -> Void)? = nil
+
+    private var visibleSessions: [TerminalSession] {
+        sessionStore.sessionsInActiveGroup
+    }
 
     var body: some View {
         HStack(spacing: 2) {
-            ForEach(sessionStore.sessions) { session in
+            ForEach(visibleSessions) { session in
                 SessionTab(
                     session: session,
                     isActive: session.id == sessionStore.activeSessionId,
                     terminalActive: session.hasStarted && sessionStore.activeXcodeProjects.contains(session.projectName),
                     terminalStatus: session.terminalStatus,
                     foregroundOpacity: sessionStore.isWindowFocused ? 1.0 : 0.6,
-                    isDragging: draggedSessionId == session.id,
-                    onSelect: { sessionStore.selectSession(session.id) },
+                    isDragging: sessionStore.draggedSessionId == session.id,
+                    allGroups: sessionStore.projectGroups,
+                    onSelect: {
+                        sessionStore.selectSession(session.id)
+                        onTabSelected?(session.id)
+                    },
                     onClose: { sessionStore.closeSession(session.id) },
                     onRename: { newName in
                         sessionStore.renameSession(session.id, to: newName)
+                    },
+                    onMoveToGroup: { groupId in
+                        sessionStore.moveSession(session.id, toGroup: groupId)
+                    },
+                    onMoveToNewGroup: { name in
+                        let newId = sessionStore.createGroup(named: name)
+                        sessionStore.moveSession(session.id, toGroup: newId)
                     }
                 )
                 .onDrag {
-                    draggedSessionId = session.id
+                    sessionStore.draggedSessionId = session.id
                     return NSItemProvider(object: session.id.uuidString as NSString)
                 }
                 .onDrop(
@@ -30,7 +45,7 @@ struct SessionTabBar: View {
                     delegate: SessionTabDropDelegate(
                         target: session,
                         sessions: $sessionStore.sessions,
-                        draggedSessionId: $draggedSessionId,
+                        draggedSessionId: $sessionStore.draggedSessionId,
                         onCommit: { sessionStore.persistSessionOrder() }
                     )
                 )
@@ -77,15 +92,20 @@ struct SessionTab: View {
     var terminalStatus: TerminalStatus = .idle
     var foregroundOpacity: Double = 1.0
     var isDragging: Bool = false
+    var allGroups: [ProjectGroup] = []
     let onSelect: () -> Void
     let onClose: () -> Void
     let onRename: (String) -> Void
+    var onMoveToGroup: ((UUID) -> Void)? = nil
+    var onMoveToNewGroup: ((String) -> Void)? = nil
 
     @State private var isHovering = false
     @State private var showRenameDialog = false
     @State private var renameText = ""
     @State private var latestCheckpoint: Checkpoint?
     @State private var showRestoreConfirmation = false
+    @State private var showNewGroupDialog = false
+    @State private var newGroupText = ""
 
     private var name: String { session.projectName }
 
@@ -179,6 +199,28 @@ struct SessionTab: View {
                 showRenameDialog = true
             }
 
+            if !allGroups.isEmpty || onMoveToNewGroup != nil {
+                Menu("Move to Project") {
+                    ForEach(allGroups) { group in
+                        Button {
+                            onMoveToGroup?(group.id)
+                        } label: {
+                            if group.id == session.groupId {
+                                Label(group.name, systemImage: "checkmark")
+                            } else {
+                                Text(group.name)
+                            }
+                        }
+                        .disabled(group.id == session.groupId)
+                    }
+                    if !allGroups.isEmpty { Divider() }
+                    Button("New Project…") {
+                        newGroupText = ""
+                        showNewGroupDialog = true
+                    }
+                }
+            }
+
             Button("Close", role: .destructive) {
                 onClose()
             }
@@ -212,11 +254,23 @@ struct SessionTab: View {
             }
             Button("Cancel", role: .cancel) {}
         }
+        .alert("New Project", isPresented: $showNewGroupDialog) {
+            TextField("Project name", text: $newGroupText)
+            Button("Create & Move") {
+                let trimmed = newGroupText.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { return }
+                onMoveToNewGroup?(trimmed)
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         .onChange(of: showRenameDialog) {
-            SessionStore.shared.isShowingDialog = showRenameDialog || showRestoreConfirmation
+            SessionStore.shared.isShowingDialog = showRenameDialog || showRestoreConfirmation || showNewGroupDialog
         }
         .onChange(of: showRestoreConfirmation) {
-            SessionStore.shared.isShowingDialog = showRenameDialog || showRestoreConfirmation
+            SessionStore.shared.isShowingDialog = showRenameDialog || showRestoreConfirmation || showNewGroupDialog
+        }
+        .onChange(of: showNewGroupDialog) {
+            SessionStore.shared.isShowingDialog = showRenameDialog || showRestoreConfirmation || showNewGroupDialog
         }
     }
 }

--- a/Notchy/SessionTabBar.swift
+++ b/Notchy/SessionTabBar.swift
@@ -1,7 +1,9 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SessionTabBar: View {
     @Bindable var sessionStore: SessionStore
+    @State private var draggedSessionId: UUID?
 
     var body: some View {
         HStack(spacing: 2) {
@@ -12,15 +14,59 @@ struct SessionTabBar: View {
                     terminalActive: session.hasStarted && sessionStore.activeXcodeProjects.contains(session.projectName),
                     terminalStatus: session.terminalStatus,
                     foregroundOpacity: sessionStore.isWindowFocused ? 1.0 : 0.6,
+                    isDragging: draggedSessionId == session.id,
                     onSelect: { sessionStore.selectSession(session.id) },
                     onClose: { sessionStore.closeSession(session.id) },
                     onRename: { newName in
                         sessionStore.renameSession(session.id, to: newName)
                     }
                 )
+                .onDrag {
+                    draggedSessionId = session.id
+                    return NSItemProvider(object: session.id.uuidString as NSString)
+                }
+                .onDrop(
+                    of: [.text],
+                    delegate: SessionTabDropDelegate(
+                        target: session,
+                        sessions: $sessionStore.sessions,
+                        draggedSessionId: $draggedSessionId,
+                        onCommit: { sessionStore.persistSessionOrder() }
+                    )
+                )
             }
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+private struct SessionTabDropDelegate: DropDelegate {
+    let target: TerminalSession
+    @Binding var sessions: [TerminalSession]
+    @Binding var draggedSessionId: UUID?
+    let onCommit: () -> Void
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedId = draggedSessionId,
+              draggedId != target.id,
+              let from = sessions.firstIndex(where: { $0.id == draggedId }),
+              let to = sessions.firstIndex(where: { $0.id == target.id }) else { return }
+        withAnimation(.easeInOut(duration: 0.18)) {
+            sessions.move(
+                fromOffsets: IndexSet(integer: from),
+                toOffset: to > from ? to + 1 : to
+            )
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedSessionId = nil
+        onCommit()
+        return true
     }
 }
 
@@ -30,6 +76,7 @@ struct SessionTab: View {
     let terminalActive: Bool
     var terminalStatus: TerminalStatus = .idle
     var foregroundOpacity: Double = 1.0
+    var isDragging: Bool = false
     let onSelect: () -> Void
     let onClose: () -> Void
     let onRename: (String) -> Void
@@ -98,6 +145,7 @@ struct SessionTab: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(isActive ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
+        .opacity(isDragging ? 0.4 : 1.0)
         .onHover { hovering in
             isHovering = hovering
             if hovering {

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -20,16 +20,22 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(claudeIntegrationEnabled, forKey: "claudeIntegrationEnabled") }
     }
 
+    var externalDisplayTrigger: Bool {
+        didSet { UserDefaults.standard.set(externalDisplayTrigger, forKey: "externalDisplayTrigger") }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
         if defaults.object(forKey: "soundsEnabled") == nil { defaults.set(true, forKey: "soundsEnabled") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
+        if defaults.object(forKey: "externalDisplayTrigger") == nil { defaults.set(false, forKey: "externalDisplayTrigger") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
+        externalDisplayTrigger = defaults.bool(forKey: "externalDisplayTrigger")
     }
 }

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -24,9 +24,27 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(claudeIntegrationEnabled, forKey: "claudeIntegrationEnabled") }
     }
 
+    var claudeAutoModeEnabled: Bool {
+        didSet { UserDefaults.standard.set(claudeAutoModeEnabled, forKey: "claudeAutoModeEnabled") }
+    }
+
     var externalDisplayTrigger: Bool {
         didSet { UserDefaults.standard.set(externalDisplayTrigger, forKey: "externalDisplayTrigger") }
     }
+
+    /// Anthropic API key used by SummaryService to generate "next steps" summaries
+    /// when a Claude Code task completes. Stored in UserDefaults for now.
+    var anthropicAPIKey: String {
+        didSet { UserDefaults.standard.set(anthropicAPIKey, forKey: "anthropicAPIKey") }
+    }
+
+    /// Claude Code accounts the user has defined. A `ProjectGroup` references one
+    /// by id to run its terminals under that account's `CLAUDE_CONFIG_DIR`.
+    var accounts: [ClaudeAccount] {
+        didSet { persistAccounts() }
+    }
+
+    private static let accountsKey = "claudeAccounts"
 
     init() {
         let defaults = UserDefaults.standard
@@ -35,6 +53,7 @@ class SettingsManager {
         if defaults.object(forKey: "muteSoundsDuringCalls") == nil { defaults.set(false, forKey: "muteSoundsDuringCalls") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
+        if defaults.object(forKey: "claudeAutoModeEnabled") == nil { defaults.set(true, forKey: "claudeAutoModeEnabled") }
         if defaults.object(forKey: "externalDisplayTrigger") == nil { defaults.set(false, forKey: "externalDisplayTrigger") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
@@ -42,6 +61,50 @@ class SettingsManager {
         muteSoundsDuringCalls = defaults.bool(forKey: "muteSoundsDuringCalls")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
+        claudeAutoModeEnabled = defaults.bool(forKey: "claudeAutoModeEnabled")
         externalDisplayTrigger = defaults.bool(forKey: "externalDisplayTrigger")
+        anthropicAPIKey = defaults.string(forKey: "anthropicAPIKey") ?? ""
+
+        if let data = defaults.data(forKey: Self.accountsKey),
+           let decoded = try? JSONDecoder().decode([ClaudeAccount].self, from: data) {
+            accounts = decoded
+        } else {
+            accounts = []
+        }
+    }
+
+    private func persistAccounts() {
+        if let data = try? JSONEncoder().encode(accounts) {
+            UserDefaults.standard.set(data, forKey: Self.accountsKey)
+        }
+    }
+
+    /// Creates a new account with a stable config-dir folder and returns it.
+    @discardableResult
+    func addAccount(named name: String) -> ClaudeAccount {
+        let id = UUID()
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        let account = ClaudeAccount(
+            id: id,
+            name: trimmed.isEmpty ? "Account" : trimmed,
+            folderName: ClaudeAccount.makeFolderName(from: trimmed, id: id)
+        )
+        accounts.append(account)
+        return account
+    }
+
+    func renameAccount(_ id: UUID, to newName: String) {
+        let trimmed = newName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, let index = accounts.firstIndex(where: { $0.id == id }) else { return }
+        accounts[index].name = trimmed
+    }
+
+    func removeAccount(_ id: UUID) {
+        accounts.removeAll { $0.id == id }
+    }
+
+    func account(for id: UUID?) -> ClaudeAccount? {
+        guard let id else { return nil }
+        return accounts.first { $0.id == id }
     }
 }

--- a/Notchy/SettingsManager.swift
+++ b/Notchy/SettingsManager.swift
@@ -12,6 +12,10 @@ class SettingsManager {
         didSet { UserDefaults.standard.set(soundsEnabled, forKey: "soundsEnabled") }
     }
 
+    var muteSoundsDuringCalls: Bool {
+        didSet { UserDefaults.standard.set(muteSoundsDuringCalls, forKey: "muteSoundsDuringCalls") }
+    }
+
     var xcodeIntegrationEnabled: Bool {
         didSet { UserDefaults.standard.set(xcodeIntegrationEnabled, forKey: "xcodeIntegrationEnabled") }
     }
@@ -28,12 +32,14 @@ class SettingsManager {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "replaceNotch") == nil { defaults.set(true, forKey: "replaceNotch") }
         if defaults.object(forKey: "soundsEnabled") == nil { defaults.set(true, forKey: "soundsEnabled") }
+        if defaults.object(forKey: "muteSoundsDuringCalls") == nil { defaults.set(false, forKey: "muteSoundsDuringCalls") }
         if defaults.object(forKey: "xcodeIntegrationEnabled") == nil { defaults.set(true, forKey: "xcodeIntegrationEnabled") }
         if defaults.object(forKey: "claudeIntegrationEnabled") == nil { defaults.set(true, forKey: "claudeIntegrationEnabled") }
         if defaults.object(forKey: "externalDisplayTrigger") == nil { defaults.set(false, forKey: "externalDisplayTrigger") }
 
         showNotch = defaults.bool(forKey: "replaceNotch")
         soundsEnabled = defaults.bool(forKey: "soundsEnabled")
+        muteSoundsDuringCalls = defaults.bool(forKey: "muteSoundsDuringCalls")
         xcodeIntegrationEnabled = defaults.bool(forKey: "xcodeIntegrationEnabled")
         claudeIntegrationEnabled = defaults.bool(forKey: "claudeIntegrationEnabled")
         externalDisplayTrigger = defaults.bool(forKey: "externalDisplayTrigger")

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -18,6 +18,7 @@ enum SettingsTab: String, CaseIterable {
 struct SettingsContentView: View {
     @State private var selectedTab: SettingsTab = .about
     var onShowNotchChanged: ((Bool) -> Void)?
+    var onExternalDisplayChanged: ((Bool) -> Void)?
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -25,7 +26,7 @@ struct SettingsContentView: View {
                 .tabItem { Label(SettingsTab.about.rawValue, systemImage: SettingsTab.about.icon) }
                 .tag(SettingsTab.about)
 
-            GeneralTab(onShowNotchChanged: onShowNotchChanged)
+            GeneralTab(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
                 .tabItem { Label(SettingsTab.general.rawValue, systemImage: SettingsTab.general.icon) }
                 .tag(SettingsTab.general)
 
@@ -40,6 +41,7 @@ struct SettingsContentView: View {
 struct GeneralTab: View {
     @Bindable private var settings = SettingsManager.shared
     var onShowNotchChanged: ((Bool) -> Void)?
+    var onExternalDisplayChanged: ((Bool) -> Void)?
 
     var body: some View {
         Form {
@@ -47,6 +49,15 @@ struct GeneralTab: View {
                 .onChange(of: settings.showNotch) { _, newValue in
                     onShowNotchChanged?(newValue)
                 }
+            Toggle(isOn: $settings.externalDisplayTrigger) {
+                Text("External display trigger")
+                Text("Hover the top-center of external displays to open the panel")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .onChange(of: settings.externalDisplayTrigger) { _, newValue in
+                onExternalDisplayChanged?(newValue)
+            }
             Toggle("Enable sounds", isOn: $settings.soundsEnabled)
         }
         .padding(20)
@@ -106,7 +117,7 @@ class SettingsWindowController {
     static let shared = SettingsWindowController()
     private var window: NSWindow?
 
-    func show(onShowNotchChanged: @escaping (Bool) -> Void) {
+    func show(onShowNotchChanged: @escaping (Bool) -> Void, onExternalDisplayChanged: @escaping (Bool) -> Void) {
         if let existing = window {
             existing.level = .floating
             existing.makeKeyAndOrderFront(nil)
@@ -114,7 +125,7 @@ class SettingsWindowController {
             return
         }
 
-        let content = SettingsContentView(onShowNotchChanged: onShowNotchChanged)
+        let content = SettingsContentView(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
         let hostingView = NSHostingView(rootView: content)
 
         let win = NSWindow(

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -59,6 +59,13 @@ struct GeneralTab: View {
                 onExternalDisplayChanged?(newValue)
             }
             Toggle("Enable sounds", isOn: $settings.soundsEnabled)
+            Toggle(isOn: $settings.muteSoundsDuringCalls) {
+                Text("Mute sounds during calls")
+                Text("Silence alerts while the microphone is in use (Zoom, Meet, FaceTime, etc.)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .disabled(!settings.soundsEnabled)
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Notchy/SettingsWindow.swift
+++ b/Notchy/SettingsWindow.swift
@@ -5,11 +5,13 @@ enum SettingsTab: String, CaseIterable {
     case about = "About"
     case general = "General"
     case integrations = "Integrations"
+    case accounts = "Accounts"
 
     var icon: String {
         switch self {
         case .general: return "gearshape"
         case .integrations: return "puzzlepiece"
+        case .accounts: return "person.crop.circle"
         case .about: return "info.circle"
         }
     }
@@ -21,20 +23,61 @@ struct SettingsContentView: View {
     var onExternalDisplayChanged: ((Bool) -> Void)?
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            AboutTab()
-                .tabItem { Label(SettingsTab.about.rawValue, systemImage: SettingsTab.about.icon) }
-                .tag(SettingsTab.about)
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    SettingsTabButton(tab: tab, isSelected: selectedTab == tab) {
+                        selectedTab = tab
+                    }
+                }
+            }
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
 
-            GeneralTab(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
-                .tabItem { Label(SettingsTab.general.rawValue, systemImage: SettingsTab.general.icon) }
-                .tag(SettingsTab.general)
+            Divider()
 
-            IntegrationsTab()
-                .tabItem { Label(SettingsTab.integrations.rawValue, systemImage: SettingsTab.integrations.icon) }
-                .tag(SettingsTab.integrations)
+            Group {
+                switch selectedTab {
+                case .about:
+                    AboutTab()
+                case .general:
+                    GeneralTab(onShowNotchChanged: onShowNotchChanged, onExternalDisplayChanged: onExternalDisplayChanged)
+                case .integrations:
+                    IntegrationsTab()
+                case .accounts:
+                    AccountsTab()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(width: 450, height: 240)
+        .frame(width: 450, height: 300)
+    }
+}
+
+struct SettingsTabButton: View {
+    let tab: SettingsTab
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: tab.icon)
+                    .font(.system(size: 16))
+                Text(tab.rawValue)
+                    .font(.system(size: 11))
+            }
+            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+            .frame(width: 68)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? Color.primary.opacity(0.08) : Color.clear)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -89,9 +132,96 @@ struct IntegrationsTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            Toggle(isOn: $settings.claudeAutoModeEnabled) {
+                Text("Auto mode")
+                Text("Launch Claude with --enable-auto-mode")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .disabled(!settings.claudeIntegrationEnabled)
+            Section {
+                SecureField("Anthropic API key", text: $settings.anthropicAPIKey)
+                    .textFieldStyle(.roundedBorder)
+                Text("Used to generate two-sentence \"next steps\" summaries when Claude finishes a task. Leave blank to disable.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+struct AccountsTab: View {
+    @Bindable private var settings = SettingsManager.shared
+    @State private var newName = ""
+    @State private var renameId: UUID?
+    @State private var renameText = ""
+
+    var body: some View {
+        Form {
+            Section("Claude Accounts") {
+                if settings.accounts.isEmpty {
+                    Text("No accounts yet. Add one below, then assign it to a project from the project menu in the panel.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(settings.accounts) { account in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(account.name)
+                            Text(account.configDirURL.path)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        Spacer()
+                        Button("Rename") {
+                            renameId = account.id
+                            renameText = account.name
+                        }
+                        Button(role: .destructive) {
+                            settings.removeAccount(account.id)
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                    }
+                }
+            }
+            Section {
+                HStack {
+                    TextField("New account name", text: $newName)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(addAccount)
+                    Button("Add", action: addAccount)
+                        .disabled(newName.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                Text("Each account uses its own Claude config directory. The first terminal you open in a project assigned to a new account will prompt you to log in.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .alert("Rename Account", isPresented: Binding(
+            get: { renameId != nil },
+            set: { if !$0 { renameId = nil } }
+        )) {
+            TextField("Name", text: $renameText)
+            Button("Rename") {
+                if let id = renameId { settings.renameAccount(id, to: renameText) }
+                renameId = nil
+            }
+            Button("Cancel", role: .cancel) { renameId = nil }
+        }
+    }
+
+    private func addAccount() {
+        let trimmed = newName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        settings.addAccount(named: trimmed)
+        newName = ""
     }
 }
 
@@ -136,7 +266,7 @@ class SettingsWindowController {
         let hostingView = NSHostingView(rootView: content)
 
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 450, height: 240),
+            contentRect: NSRect(x: 0, y: 0, width: 450, height: 300),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Notchy/SummaryService.swift
+++ b/Notchy/SummaryService.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Calls the Anthropic Messages API to produce a 2-sentence "next steps" summary
+/// of recently-completed Claude Code activity.
+actor SummaryService {
+    static let shared = SummaryService()
+
+    private static let endpoint = URL(string: "https://api.anthropic.com/v1/messages")!
+    private static let model = "claude-haiku-4-5-20251001"
+    private static let anthropicVersion = "2023-06-01"
+
+    enum SummaryError: Error {
+        case missingAPIKey
+        case badResponse
+    }
+
+    func summarize(terminalOutput: String, lastRequest: String?) async throws -> String {
+        let apiKey = SettingsManager.shared.anthropicAPIKey
+        guard !apiKey.isEmpty else {
+            print("[summary-svc] missing API key")
+            throw SummaryError.missingAPIKey
+        }
+        print("[summary-svc] preparing request: terminalOutput=\(terminalOutput.count) chars, lastRequest=\(lastRequest.map { "\"\($0)\"" } ?? "nil")")
+
+        let requestLine = lastRequest.map { "The user's most recent request was: \"\($0)\"\n\n" } ?? ""
+        let prompt = """
+        You are summarizing the result of a Claude Code session that just finished a task. \
+        \(requestLine)Below is the recent terminal output. Write exactly two short sentences:
+        1) What Claude just completed (be specific — file names, behaviors).
+        2) What the user should verify, run, or do next.
+
+        No preamble, no markdown, no bullets. Plain prose.
+
+        Terminal output:
+        \(terminalOutput)
+        """
+
+        let body: [String: Any] = [
+            "model": Self.model,
+            "max_tokens": 250,
+            "messages": [
+                ["role": "user", "content": prompt]
+            ]
+        ]
+
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
+
+        print("[summary-svc] POST \(Self.endpoint.absoluteString) (model=\(Self.model))")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let http = response as? HTTPURLResponse
+        print("[summary-svc] HTTP \(http?.statusCode ?? -1), body=\(data.count) bytes")
+        guard let http, (200..<300).contains(http.statusCode) else {
+            let bodyPreview = String(data: data.prefix(500), encoding: .utf8) ?? "<non-utf8>"
+            print("[summary-svc] non-2xx body: \(bodyPreview)")
+            throw SummaryError.badResponse
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let first = content.first,
+              let text = first["text"] as? String else {
+            print("[summary-svc] could not parse response JSON")
+            throw SummaryError.badResponse
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Notchy/TerminalManager.swift
+++ b/Notchy/TerminalManager.swift
@@ -4,6 +4,10 @@ import SwiftTerm
 class ClickThroughTerminalView: LocalProcessTerminalView {
     var sessionId: UUID?
     private var keyMonitor: Any?
+    // Held until the shell signals readiness (first OSC 7 cwd report = first
+    // prompt drawn). Sending input right after startProcess races login-shell
+    // init, which can flush the tty input queue and silently drop the command.
+    private var pendingStartupCommand: String?
     private var statusDebounceWork: DispatchWorkItem?
     private static let statusQueue = DispatchQueue(label: "com.notchy.status", qos: .utility)
 
@@ -58,6 +62,24 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
         }
     }
 
+    /// Queues a command to send once the shell is ready, with a timer fallback
+    /// for shells that never emit OSC 7 (e.g. bash without the Apple_Terminal rc).
+    func queueStartupCommand(_ text: String, fallbackAfter seconds: TimeInterval) {
+        pendingStartupCommand = text
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
+            self?.flushPendingStartupCommand()
+        }
+    }
+
+    /// Sends the queued startup command if one is still pending. Must be called
+    /// on the main thread; idempotent so the OSC 7 trigger and the fallback
+    /// timer can both fire.
+    func flushPendingStartupCommand() {
+        guard let command = pendingStartupCommand else { return }
+        pendingStartupCommand = nil
+        send(txt: command)
+    }
+
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         return .copy
     }
@@ -72,7 +94,21 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
     }
 
     /// Returns all visible lines from the terminal buffer.
-    private func extractAllLines() -> [String]? {
+    ///
+    /// SwiftTerm's `Terminal`/`Buffer` is NOT thread-safe. Reading the buffer
+    /// off the main thread races with main-thread reflow/resize mutations and
+    /// corrupts the buffer's array storage — a SIGABRT crash ("object
+    /// deallocated with non-zero retain count"). So the actual buffer read is
+    /// always marshalled onto the main thread; callers may invoke this from any
+    /// queue and get back a plain `[String]` snapshot they can parse anywhere.
+    func extractAllLines() -> [String]? {
+        if Thread.isMainThread {
+            return extractAllLinesOnMain()
+        }
+        return DispatchQueue.main.sync { extractAllLinesOnMain() }
+    }
+
+    private func extractAllLinesOnMain() -> [String]? {
         let terminal = getTerminal()
         guard terminal.rows >= 20 else { return nil }
         var lineTexts: [String] = []
@@ -94,24 +130,277 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
     }
 
     /// Returns the last 20 non-blank lines of terminal output above the prompt separator.
-    func extractVisibleText() -> String? {
-        guard var lineTexts = extractAllLines() else { return nil }
+    func extractVisibleText(from lines: [String]) -> String? {
+        var lineTexts = lines
 
         // Find the last horizontal rule separator (────...) which divides
         // Claude's output from the user's current prompt input area.
         // Only consider text above it so we don't capture the in-progress prompt.
-        let separator = "────────"
-        if let lastSeparatorIndex = lineTexts.lastIndex(where: { $0.contains(separator) }) {
+        // Exclude box-corner lines (╭───╮ / ╰───╯) since the top of the input box
+        // also contains long runs of ─ and would otherwise be matched first.
+        if let lastSeparatorIndex = lineTexts.lastIndex(where: Self.isPlainHorizontalRule) {
             lineTexts = Array(lineTexts.prefix(lastSeparatorIndex))
         }
 
         return relevantText(from: lineTexts)
     }
 
+    private static func isPlainHorizontalRule(_ line: String) -> Bool {
+        guard line.contains("────────") else { return false }
+        for ch in line {
+            if "╭╮╰╯│".contains(ch) { return false }
+        }
+        return true
+    }
+
     /// Returns the last 20 non-blank lines of the full terminal output (including prompt area).
-    func extractFullVisibleText() -> String? {
-        guard let lineTexts = extractAllLines() else { return nil }
-        return relevantText(from: lineTexts)
+    func extractFullVisibleText(from lines: [String]) -> String? {
+        return relevantText(from: lines)
+    }
+
+    /// Extracts Claude's numbered prompt choices, the question text immediately
+    /// above them (e.g. "Do you want to proceed?"), and any preview block above
+    /// the question (e.g. a diff for an edit confirmation). Returns empty choices
+    /// / nil question / nil preview when no numbered prompt is visible.
+    func extractPromptBlock(from lines: [String]) -> (choices: [PromptChoice], question: String?, preview: String?) {
+        return Self.parsePromptBlock(from: lines)
+    }
+
+    fileprivate static func parsePromptBlock(from lines: [String]) -> (choices: [PromptChoice], question: String?, preview: String?) {
+        func match(_ line: String) -> (isSelected: Bool, number: Int, label: String)? {
+            var trimmed = Substring(line).drop(while: { $0 == " " })
+            // Some prompts wrap each line in a box: "│  ❯ 1. Yes    │"
+            if trimmed.hasPrefix("│") {
+                trimmed = trimmed.dropFirst().drop(while: { $0 == " " })
+            }
+            let isSelected = trimmed.hasPrefix("❯ ")
+            if isSelected { trimmed = trimmed.dropFirst(2).drop(while: { $0 == " " }) }
+            let digits = trimmed.prefix(while: { $0.isNumber })
+            guard !digits.isEmpty, let number = Int(digits) else { return nil }
+            var rest = trimmed.dropFirst(digits.count)
+            guard rest.first == "." else { return nil }
+            rest = rest.dropFirst()
+            guard rest.first == " " else { return nil }
+            var label = String(rest.dropFirst())
+            if label.hasSuffix("│") { label = String(label.dropLast()) }
+            label = label.trimmingCharacters(in: .whitespaces)
+            guard !label.isEmpty else { return nil }
+            return (isSelected, number, label)
+        }
+
+        // Lines that definitively end the option block — separators, input box
+        // borders, or the input prompt arrow itself. AskUserQuestion options can
+        // include indented description text between numbered items, so we can't
+        // stop on "first non-matching line".
+        func isBoundary(_ line: String) -> Bool {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { return false }
+            if isPlainHorizontalRule(line) { return true }
+            if trimmed.hasPrefix("╭") || trimmed.hasPrefix("╰") { return true }
+            // `❯ ` lines that aren't numbered choices are the input prompt area.
+            if trimmed.hasPrefix("❯ "), match(line) == nil { return true }
+            return false
+        }
+
+        // Anchor on the last selection arrow — that's the bottom of the active prompt.
+        guard let anchor = lines.lastIndex(where: { match($0)?.isSelected == true }) else {
+            return ([], nil, nil)
+        }
+
+        var collected: [(idx: Int, choice: PromptChoice)] = []
+        var seen = Set<Int>()
+        // Allow up to this many consecutive non-matching, non-boundary lines
+        // (option descriptions, wrapped text) before giving up on the option block.
+        let maxGap = 4
+
+        // Walk downward from the anchor.
+        var i = anchor
+        var gap = 0
+        while i < lines.count {
+            if isBoundary(lines[i]) { break }
+            if let m = match(lines[i]) {
+                if seen.insert(m.number).inserted {
+                    collected.append((i, PromptChoice(number: m.number, label: m.label, isSelected: m.isSelected)))
+                }
+                gap = 0
+            } else {
+                gap += 1
+                if gap > maxGap { break }
+            }
+            i += 1
+        }
+
+        // Walk upward.
+        var j = anchor - 1
+        var topChoiceIdx = anchor
+        gap = 0
+        while j >= 0 {
+            if isBoundary(lines[j]) { break }
+            if let m = match(lines[j]) {
+                if seen.insert(m.number).inserted {
+                    collected.append((j, PromptChoice(number: m.number, label: m.label, isSelected: m.isSelected)))
+                }
+                topChoiceIdx = j
+                gap = 0
+            } else {
+                gap += 1
+                if gap > maxGap { break }
+            }
+            j -= 1
+        }
+
+        let sortedChoices = collected.sorted { $0.choice.number < $1.choice.number }.map { $0.choice }
+        let (question, questionIdx) = extractQuestion(from: lines, aboveLineIndex: topChoiceIdx)
+        let preview = questionIdx.flatMap { extractPreview(from: lines, aboveQuestionAt: $0) }
+        return (sortedChoices, question, preview)
+    }
+
+    /// Finds the question line (e.g. "Do you want to proceed?") that appears
+    /// immediately above the numbered choices. Walks upward from `aboveLineIndex`,
+    /// stripping box borders, skipping blank lines, and returns the first
+    /// non-empty content line along with its index. Returns (nil, nil) if a
+    /// structural boundary (top box border or horizontal rule) is hit before
+    /// any text is found.
+    fileprivate static func extractQuestion(from lines: [String], aboveLineIndex: Int) -> (text: String?, index: Int?) {
+        var k = aboveLineIndex - 1
+        while k >= 0 {
+            let raw = lines[k]
+            // Strip leading whitespace and `│` border on either side.
+            var t = String(raw.drop(while: { $0 == " " }))
+            if t.hasPrefix("│") { t = String(t.dropFirst()) }
+            if t.hasSuffix("│") { t = String(t.dropLast()) }
+            t = t.trimmingCharacters(in: .whitespaces)
+
+            if t.isEmpty { k -= 1; continue }
+            // Structural boundaries — we've walked out of the prompt block.
+            if t.hasPrefix("╭") || t.hasPrefix("╰") { return (nil, nil) }
+            if isPlainHorizontalRule(raw) { return (nil, nil) }
+            return (t, k)
+        }
+        return (nil, nil)
+    }
+
+    /// Captures the preview content above the question — typically a diff for
+    /// an edit confirmation, or the command/url body for tool-use prompts.
+    /// Walks past the rule separator below the preview, then up through content
+    /// lines (treating intra-preview rules as separators) until a structural
+    /// boundary or the line cap is hit. Returns nil when no preview exists.
+    fileprivate static func extractPreview(from lines: [String], aboveQuestionAt: Int) -> String? {
+        var k = aboveQuestionAt - 1
+        var crossedRule = false
+        // Walk up through blank lines and a single rule separator to enter the preview region.
+        while k >= 0 {
+            let raw = lines[k]
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { k -= 1; continue }
+            if isPlainHorizontalRule(raw) {
+                if crossedRule { break }
+                crossedRule = true
+                k -= 1
+                continue
+            }
+            if trimmed.hasPrefix("╭") || trimmed.hasPrefix("╰") { return nil }
+            break
+        }
+        // No rule between question and the next content → no preview block.
+        if !crossedRule { return nil }
+
+        var previewLines: [String] = []
+        let maxLines = 18
+        while k >= 0 && previewLines.count < maxLines {
+            let raw = lines[k]
+            var t = String(raw.drop(while: { $0 == " " }))
+            let trimmed = t.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("╭") || trimmed.hasPrefix("╰") { break }
+            // Intra-preview rules (e.g. between an "Edit file" header and the diff)
+            // get skipped rather than ending the block.
+            if isPlainHorizontalRule(raw) { k -= 1; continue }
+
+            if t.hasPrefix("│") { t = String(t.dropFirst()) }
+            if t.hasSuffix("│") { t = String(t.dropLast()) }
+            while t.last == " " { t.removeLast() }
+
+            previewLines.insert(t, at: 0)
+            k -= 1
+        }
+
+        while previewLines.first?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            previewLines.removeFirst()
+        }
+        while previewLines.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            previewLines.removeLast()
+        }
+        if previewLines.isEmpty { return nil }
+        return previewLines.joined(separator: "\n")
+    }
+
+    /// Extracts the text the user has typed into Claude's input box.
+    /// Handles both the current Claude TUI (`❯ <text>` bracketed by `───` rule separators)
+    /// and the legacy `╭…╰` box format. Returns nil when no input is visible.
+    func extractPromptInput(from lines: [String]) -> String? {
+        // Rule-anchored: `❯ <text>` line adjacent to a horizontal-rule separator.
+        for (idx, line) in lines.enumerated() {
+            guard let content = Self.promptInputContent(line) else { continue }
+            let lo = max(0, idx - 2)
+            let hi = min(lines.count - 1, idx + 2)
+            let nearSeparator = (lo...hi).contains { i in
+                i != idx && Self.isPlainHorizontalRule(lines[i])
+            }
+            guard nearSeparator else { continue }
+            return content
+        }
+
+        // Fallback: the rule check sometimes fails (terminal rendering edge cases
+        // with pasted text, color attributes, etc.). Any `❯ <non-placeholder>` line
+        // in the bottom slice of the buffer is treated as live input — Claude's TUI
+        // only emits `❯` for the active prompt area, never for scrollback messages.
+        let nonBlank = lines.filter { !$0.allSatisfy({ $0 == " " }) }
+        for line in nonBlank.suffix(12).reversed() {
+            guard let content = Self.promptInputContent(line) else { continue }
+            return content
+        }
+
+        // Legacy fallback: `╭…╰` box.
+        let sepIdx = lines.lastIndex(where: Self.isPlainHorizontalRule)
+        let startIdx = sepIdx.map { $0 + 1 } ?? 0
+
+        var inputLines: [String] = []
+        var insideBox = false
+        for line in lines[startIdx...] {
+            let trimmed = String(line.drop(while: { $0 == " " }))
+            if trimmed.hasPrefix("╭") { insideBox = true; continue }
+            if trimmed.hasPrefix("╰") { break }
+            guard insideBox else { continue }
+
+            var content = trimmed
+            if content.hasPrefix("│") { content = String(content.dropFirst()) }
+            if content.hasSuffix("│") { content = String(content.dropLast()) }
+            content = content.trimmingCharacters(in: .whitespaces)
+            if content.hasPrefix("> ") { content = String(content.dropFirst(2)) }
+            if !content.isEmpty {
+                inputLines.append(content)
+            }
+        }
+
+        let result = inputLines.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+        return result.isEmpty ? nil : result
+    }
+
+    /// Returns the text after `❯ ` on the given line, if it's a text-input prompt.
+    /// Returns nil for numbered choices (`❯ 1. Yes`) and Claude's `Try "..."` placeholder.
+    fileprivate static func promptInputContent(_ line: String) -> String? {
+        let trimmed = line.drop(while: { $0 == " " })
+        guard trimmed.hasPrefix("❯ ") else { return nil }
+        let rest = trimmed.dropFirst(2)
+        if let first = rest.first, first.isNumber {
+            let digits = rest.prefix(while: { $0.isNumber })
+            if rest.dropFirst(digits.count).first == "." { return nil }
+        }
+        let content = String(rest).trimmingCharacters(in: .whitespaces)
+        if content.isEmpty { return nil }
+        if content.hasPrefix("Try \"") && content.hasSuffix("\"") { return nil }
+        return content
     }
 
     override func dataReceived(slice: ArraySlice<UInt8>) {
@@ -119,27 +408,35 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
 
         guard let id = sessionId else { return }
 
-        // Debounce status checks on a background queue to avoid
-        // blocking the main thread with per-cell buffer reads.
-        statusDebounceWork?.cancel()
+        // Schedule a check 150ms after the first byte of a burst, but DON'T
+        // reset the timer on every subsequent byte. Continuous data (spinner
+        // animations, fast typing, paste echoes) would otherwise reschedule
+        // faster than the debounce window and we'd never sample.
+        if statusDebounceWork != nil { return }
         let work = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.evaluateStatus(for: id)
+            DispatchQueue.main.async { self.statusDebounceWork = nil }
         }
         statusDebounceWork = work
         Self.statusQueue.asyncAfter(deadline: .now() + 0.15, execute: work)
     }
 
     private func evaluateStatus(for id: UUID) {
-        guard let visibleText = extractVisibleText() else { return }
-        let fullText = extractFullVisibleText() ?? visibleText
+        // Snapshot the buffer once on the main thread (extractAllLines marshals
+        // there); everything below is pure string parsing, safe on any queue.
+        guard let lines = extractAllLines() else { return }
+        guard let visibleText = extractVisibleText(from: lines) else { return }
+        let fullText = extractFullVisibleText(from: lines) ?? visibleText
 
-        let newStatus: TerminalStatus
+        var newStatus: TerminalStatus
 
         if Self.hasTokenCounterLine(visibleText) || fullText.contains("esc to interrupt") {
             newStatus = .working
         }
         else if fullText.contains("Esc to cancel") || Self.hasUserPrompt(fullText) {
+            // Only a genuine pending question — confirmation overlay ("Esc to cancel")
+            // or numbered choices. A bare input box is just normal idle.
             newStatus = .waitingForInput
         } else if visibleText.contains("Interrupted") {
             newStatus = .interrupted
@@ -147,11 +444,47 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
             newStatus = .idle
         }
 
-        if !SessionStore.shared.sessions.contains(where: {$0.id == id && $0.terminalStatus == newStatus}) {
-            DispatchQueue.main.async {
+        // Scrape pending prompt text unconditionally — status detection sometimes
+        // mis-fires (computes .idle while the user is actively typing into the
+        // input box), and the store's nil-guard protects against the Enter-wipe
+        // race regardless of computed status.
+        let pendingPrompt: String? = extractPromptInput(from: lines)
+        // Capture interactive numbered choices + the question line above them + the preview block.
+        var block: (choices: [PromptChoice], question: String?, preview: String?) =
+            (newStatus == .waitingForInput) ? extractPromptBlock(from: lines) : ([], nil, nil)
+        // Demote to .idle if we flagged .waitingForInput but couldn't actually
+        // find a numbered prompt — e.g. the user's typed draft started with a
+        // digit and tripped `hasUserPrompt`'s `❯ <digit>` match.
+        if newStatus == .waitingForInput && block.choices.isEmpty {
+            newStatus = .idle
+            block = ([], nil, nil)
+        }
+        // Capture Claude's spinner/status line while working
+        let activity: String? = (newStatus == .working) ? Self.activityLine(visibleText) : nil
+
+        DispatchQueue.main.async {
+            // Update pendingPromptText BEFORE the status transition so the
+            // .working transition's freeze sees the latest scraped text. The
+            // store's nil-guard preserves the draft during the Enter-wipe flicker.
+            SessionStore.shared.updatePendingPromptText(id, text: pendingPrompt)
+            if !SessionStore.shared.sessions.contains(where: { $0.id == id && $0.terminalStatus == newStatus }) {
                 SessionStore.shared.updateTerminalStatus(id, status: newStatus)
             }
+            SessionStore.shared.updatePendingChoices(id, choices: block.choices, question: block.question, preview: block.preview)
+            SessionStore.shared.updateActivityLine(id, line: activity)
         }
+    }
+
+    /// Returns the Claude activity/spinner line (e.g. "✻ Brewing… (3s · ↑ 1.2k tokens · esc to interrupt)").
+    private static func activityLine(_ text: String) -> String? {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        for line in lines.reversed() {
+            guard let first = line.first, spinnerCharacters.contains(first) else { continue }
+            guard line.dropFirst().first == " " else { continue }
+            guard line.contains("…") else { continue }
+            return line.trimmingCharacters(in: .whitespaces)
+        }
+        return nil
     }
 
     /// Checks whether the text contains a Claude spinner character (visible during working state)
@@ -179,6 +512,26 @@ class ClickThroughTerminalView: LocalProcessTerminalView {
                 trimmed.dropFirst().first == " " &&
                 trimmed.dropFirst(2).first?.isNumber == true
         }
+    }
+
+    /// Detects the current Claude TUI's text input: `❯ <text>` line bracketed by `───` rules.
+    /// (The older `hasUserPrompt` only catches numbered-choice prompts.)
+    private static func hasPromptInputLine(_ text: String) -> Bool {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        for (idx, line) in lines.enumerated() {
+            guard promptInputContent(line) != nil else { continue }
+            let lo = max(0, idx - 2)
+            let hi = min(lines.count - 1, idx + 2)
+            for i in lo...hi where i != idx {
+                if isPlainHorizontalRule(lines[i]) { return true }
+            }
+        }
+        // Fallback paired with extractPromptInput: rule check sometimes fails,
+        // but a `❯ <non-placeholder>` line near the bottom is still live input.
+        for line in lines.suffix(12) {
+            if promptInputContent(line) != nil { return true }
+        }
+        return false
     }
 
     private static func hasTokenCounterLine(_ text: String) -> Bool {
@@ -211,22 +564,32 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
         terminal.nativeForegroundColor = NSColor(white: 0.9, alpha: 1.0)
 
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-        let environment = buildEnvironment()
+        let environment = buildEnvironment(claudeConfigDir: Self.claudeConfigDir(for: sessionId))
 
+        // A nonexistent directory makes the child's chdir fail silently and the
+        // shell would inherit the app's own cwd ("/") — fall back to home instead.
+        var startDirectory = workingDirectory
+        if startDirectory.isEmpty || !FileManager.default.fileExists(atPath: startDirectory) {
+            startDirectory = NSHomeDirectory()
+        }
+
+        // Spawn the shell directly in the working directory rather than typing
+        // a `cd` into it — input sent during login-shell init can be flushed
+        // and silently dropped.
         terminal.startProcess(
             executable: shell,
             args: ["--login"],
             environment: environment,
-            execName: "-" + (shell as NSString).lastPathComponent
+            execName: "-" + (shell as NSString).lastPathComponent,
+            currentDirectory: startDirectory
         )
 
-        // cd to working directory, launch claude only if CLAUDE.md exists and integration is enabled
-        let escapedDir = shellEscape(workingDirectory)
+        // Launch claude only if CLAUDE.md exists and integration is enabled.
+        // Queued until the first OSC 7 cwd report (= first prompt) for the same reason.
         let hasClaude = launchClaude && SettingsManager.shared.claudeIntegrationEnabled && FileManager.default.fileExists(atPath: (workingDirectory as NSString).appendingPathComponent("CLAUDE.md"))
         if hasClaude {
-            terminal.send(txt: "cd \(escapedDir) && clear && claude\r")
-        } else {
-            terminal.send(txt: "cd \(escapedDir) && clear\r")
+            let claudeCommand = SettingsManager.shared.claudeAutoModeEnabled ? "claude --enable-auto-mode" : "claude"
+            terminal.queueStartupCommand("clear && \(claudeCommand)\r", fallbackAfter: 3.0)
         }
 
         terminals[sessionId] = terminal
@@ -240,12 +603,36 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
     func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
 
     func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {
-        guard let dir = directory,
-              let terminal = source as? ClickThroughTerminalView,
-              let sessionId = terminal.sessionId else { return }
+        guard let terminal = source as? ClickThroughTerminalView else { return }
+        // First OSC 7 report means the shell finished init and drew its prompt —
+        // it's now safe to send the queued startup command.
         DispatchQueue.main.async {
-            SessionStore.shared.updateWorkingDirectory(sessionId, directory: dir)
+            terminal.flushPendingStartupCommand()
         }
+        guard let raw = directory,
+              let sessionId = terminal.sessionId,
+              let path = Self.parseOSC7Path(raw) else { return }
+        DispatchQueue.main.async {
+            SessionStore.shared.updateWorkingDirectory(sessionId, directory: path)
+        }
+    }
+
+    /// Parses an OSC 7 payload (e.g. `file://hostname/Users/foo/My%20Project`) into
+    /// a plain filesystem path. Returns nil for empty, malformed, or non-existent paths.
+    static func parseOSC7Path(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let path: String
+        if let url = URL(string: trimmed), url.isFileURL {
+            path = url.path
+        } else if trimmed.hasPrefix("/") {
+            path = trimmed.removingPercentEncoding ?? trimmed
+        } else {
+            return nil
+        }
+        guard !path.isEmpty,
+              FileManager.default.fileExists(atPath: path) else { return nil }
+        return path
     }
 
     func processTerminated(source: TerminalView, exitCode: Int32?) {}
@@ -253,21 +640,45 @@ class TerminalManager: NSObject, LocalProcessTerminalViewDelegate {
     /// Returns the visible text from a terminal's buffer
     func visibleText(for sessionId: UUID) -> String? {
         guard let terminal = terminals[sessionId] as? ClickThroughTerminalView else { return nil }
-        return terminal.extractVisibleText()
+        guard let lines = terminal.extractAllLines() else { return nil }
+        return terminal.extractVisibleText(from: lines)
+    }
+
+    /// Sends raw input to a session's terminal (used by Conductor to submit numbered choices).
+    func sendInput(to sessionId: UUID, text: String) {
+        terminals[sessionId]?.send(txt: text)
     }
 
     func destroyTerminal(for sessionId: UUID) {
         terminals.removeValue(forKey: sessionId)
     }
 
-    private func buildEnvironment() -> [String] {
+    /// Resolves the `CLAUDE_CONFIG_DIR` for a session by walking session → group
+    /// → account. Returns nil for the default `~/.claude` login. Creates the
+    /// account's config dir on demand so `claude` can write credentials into it.
+    private static func claudeConfigDir(for sessionId: UUID) -> String? {
+        guard let groupId = SessionStore.shared.sessions.first(where: { $0.id == sessionId })?.groupId,
+              let group = SessionStore.shared.projectGroups.first(where: { $0.id == groupId }),
+              let account = SettingsManager.shared.account(for: group.accountId) else { return nil }
+        let url = account.configDirURL
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.path
+    }
+
+    private func buildEnvironment(claudeConfigDir: String? = nil) -> [String] {
         var env = ProcessInfo.processInfo.environment
         env["TERM"] = "xterm-256color"
         env["LANG"] = env["LANG"] ?? "en_US.UTF-8"
+        // Per-project Claude account: point claude at this account's own config
+        // directory so it uses that account's credentials.
+        if let claudeConfigDir { env["CLAUDE_CONFIG_DIR"] = claudeConfigDir }
+        // macOS's stock zsh/bash only emit OSC 7 cwd reports (which feed
+        // hostCurrentDirectoryUpdate → session persistence) when
+        // /etc/zshrc_Apple_Terminal is sourced, gated on this variable.
+        env["TERM_PROGRAM"] = "Apple_Terminal"
+        // Without a session ID the Apple_Terminal rc skips its shell-session
+        // save/restore machinery — we only want the cwd reporting.
+        env.removeValue(forKey: "TERM_SESSION_ID")
         return env.map { "\($0.key)=\($0.value)" }
-    }
-
-    private func shellEscape(_ path: String) -> String {
-        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/Notchy/TerminalPanel.swift
+++ b/Notchy/TerminalPanel.swift
@@ -8,17 +8,31 @@ class ClickThroughHostingView<Content: View>: NSHostingView<Content> {
 class TerminalPanel: NSPanel {
     private let sessionStore: SessionStore
     private static let collapsedHeight: CGFloat = 44
-    private var expandedHeight: CGFloat = 500
+    private static let defaultExpandedHeight: CGFloat = 400
+    private static let defaultWidth: CGFloat = 720
+    private static let minWidth: CGFloat = 480
+    private static let minExpandedHeight: CGFloat = 300
+    private static let savedFrameKey = "panelSavedFrame"
+    private var expandedHeight: CGFloat = defaultExpandedHeight
+    private var hasRestoredFrame = false
 
     init(sessionStore: SessionStore) {
         self.sessionStore = sessionStore
 
+        let savedFrame = Self.loadSavedFrame()
+        let initialRect = savedFrame ?? NSRect(x: 0, y: 0, width: Self.defaultWidth, height: Self.defaultExpandedHeight)
+
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 720, height: 400),
+            contentRect: initialRect,
             styleMask: [.borderless, .resizable, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
             defer: true
         )
+
+        if savedFrame != nil {
+            hasRestoredFrame = true
+            expandedHeight = initialRect.height
+        }
 
         isFloatingPanel = true
         level = .floating
@@ -28,7 +42,7 @@ class TerminalPanel: NSPanel {
         isOpaque = false
         animationBehavior = .none
         hidesOnDeactivate = false
-        minSize = NSSize(width: 480, height: 300)
+        minSize = NSSize(width: Self.minWidth, height: Self.minExpandedHeight)
 
         let contentView = PanelContentView(
             sessionStore: sessionStore,
@@ -65,10 +79,42 @@ class TerminalPanel: NSPanel {
             name: .NotchyExpandPanel,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(panelFrameChanged),
+            name: NSWindow.didMoveNotification,
+            object: self
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(panelFrameChanged),
+            name: NSWindow.didEndLiveResizeNotification,
+            object: self
+        )
+    }
+
+    @objc private func panelFrameChanged() {
+        // Only persist while expanded — the collapsed frame has a fixed height
+        // and a shifted Y origin that we don't want to restore on next launch.
+        guard sessionStore.isTerminalExpanded else { return }
+        UserDefaults.standard.set(NSStringFromRect(frame), forKey: Self.savedFrameKey)
+        hasRestoredFrame = true
+        expandedHeight = frame.height
+    }
+
+    private static func loadSavedFrame() -> NSRect? {
+        guard let str = UserDefaults.standard.string(forKey: savedFrameKey), !str.isEmpty else { return nil }
+        let rect = NSRectFromString(str)
+        guard rect.width >= minWidth, rect.height >= minExpandedHeight else { return nil }
+        guard NSScreen.screens.contains(where: { $0.frame.intersects(rect) }) else { return nil }
+        return rect
     }
 
     func showPanel(below rect: NSRect) {
-        if let screen = NSScreen.main {
+        let targetScreen = NSScreen.screens.first { $0.frame.intersects(rect) } ?? NSScreen.main
+        if let screen = targetScreen, !hasRestoredFrame || !currentFrameIsOn(screen) {
             let panelWidth = frame.width
             let panelHeight = frame.height
             let x = rect.midX - panelWidth / 2
@@ -80,14 +126,27 @@ class TerminalPanel: NSPanel {
     }
 
     func showPanelCentered(on screen: NSScreen) {
-        let screenFrame = screen.frame
-        let panelWidth = frame.width
-        let panelHeight = frame.height
-        let x = screenFrame.midX - panelWidth / 2
-        let y = screenFrame.maxY - panelHeight
-        setFrameOrigin(NSPoint(x: x, y: y))
+        if !hasRestoredFrame || !currentFrameIsOn(screen) {
+            let screenFrame = screen.frame
+            let panelWidth = frame.width
+            let panelHeight = frame.height
+            let x = screenFrame.midX - panelWidth / 2
+            let y = screenFrame.maxY - panelHeight
+            setFrameOrigin(NSPoint(x: x, y: y))
+        }
         makeKeyAndOrderFront(nil)
         NotificationCenter.default.post(name: .NotchyNotchStatusChanged, object: nil)
+    }
+
+    /// True when the majority of the panel's current frame lies on `screen`.
+    /// Used to decide whether a saved frame is still valid for the screen the
+    /// user is triggering from — after display config changes or when hovering
+    /// a different display's notch, the saved frame can be on the wrong screen.
+    private func currentFrameIsOn(_ screen: NSScreen) -> Bool {
+        let intersection = frame.intersection(screen.frame)
+        let panelArea = frame.width * frame.height
+        guard panelArea > 0 else { return false }
+        return (intersection.width * intersection.height) / panelArea >= 0.5
     }
 
     func hidePanel() {

--- a/Notchy/TerminalSession.swift
+++ b/Notchy/TerminalSession.swift
@@ -13,6 +13,66 @@ enum TerminalStatus: Equatable {
     case taskCompleted
 }
 
+enum SummaryStatus: String, Equatable, Codable {
+    case none
+    case generating
+    case ready
+    case failed
+}
+
+/// One prompt-and-response cycle inside a session: the request the user
+/// submitted, an LLM-generated summary of what Claude did, and whether the
+/// user has ticked off the work as verified.
+struct TaskExchange: Identifiable, Equatable, Codable {
+    let id: UUID
+    let prompt: String
+    let promptAt: Date
+    var completedAt: Date?
+    var summary: String?
+    var summaryStatus: SummaryStatus
+    var verified: Bool
+    /// True when the user pressed Esc during this exchange. Renders an orange
+    /// "!" badge in place of the verified checkbox.
+    var wasInterrupted: Bool
+
+    init(prompt: String, promptAt: Date = Date()) {
+        self.id = UUID()
+        self.prompt = prompt
+        self.promptAt = promptAt
+        self.completedAt = nil
+        self.summary = nil
+        self.summaryStatus = .none
+        self.verified = false
+        self.wasInterrupted = false
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, prompt, promptAt, completedAt, summary, summaryStatus, verified, wasInterrupted
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.prompt = try c.decode(String.self, forKey: .prompt)
+        self.promptAt = try c.decode(Date.self, forKey: .promptAt)
+        self.completedAt = try c.decodeIfPresent(Date.self, forKey: .completedAt)
+        self.summary = try c.decodeIfPresent(String.self, forKey: .summary)
+        self.summaryStatus = try c.decodeIfPresent(SummaryStatus.self, forKey: .summaryStatus) ?? .none
+        self.verified = try c.decodeIfPresent(Bool.self, forKey: .verified) ?? false
+        self.wasInterrupted = try c.decodeIfPresent(Bool.self, forKey: .wasInterrupted) ?? false
+    }
+}
+
+/// A numbered choice extracted from Claude's interactive prompt
+/// (e.g. "❯ 1. Yes", "  2. No"). `isSelected` reflects which option
+/// Claude's UI has highlighted with the ❯ arrow.
+struct PromptChoice: Equatable, Identifiable {
+    var id: Int { number }
+    let number: Int
+    let label: String
+    let isSelected: Bool
+}
+
 struct TerminalSession: Identifiable {
     let id: UUID
     var projectName: String
@@ -26,8 +86,33 @@ struct TerminalSession: Identifiable {
     let createdAt: Date
     /// When the session most recently entered the .working state
     var workingStartedAt: Date?
+    /// Continuously-updated snapshot of what the user is currently typing in Claude's prompt box
+    var pendingPromptText: String?
+    /// Ordered prompt/response history for this session. New exchanges are pushed
+    /// on the .working transition (when the user submits a prompt) and get their
+    /// summary filled in when the task completes.
+    var exchanges: [TaskExchange]
+    /// Live activity/spinner line scraped from the terminal while Claude is working
+    /// (e.g. "✻ Brewing… (3s · ↑ 1.2k tokens · esc to interrupt)")
+    var activityLine: String?
+    /// Numbered choices Claude is currently offering (only populated in .waitingForInput)
+    var pendingChoices: [PromptChoice]
+    /// The question line above the numbered choices (e.g. "Do you want to proceed?").
+    /// Only populated in .waitingForInput.
+    var pendingQuestion: String?
+    /// Preview content above the question — typically a diff/file header for edit
+    /// confirmations, or the body of a `WebFetch` / `Bash` command preview. Lines
+    /// are joined with `\n`. Only populated in .waitingForInput.
+    var pendingPromptPreview: String?
+    /// Project group this session belongs to. nil during migration / before
+    /// auto-assignment runs; SessionStore resolves it to a real group on first
+    /// touch via the session's git root.
+    var groupId: UUID?
 
-    init(projectName: String, projectPath: String? = nil, workingDirectory: String? = nil, started: Bool = false) {
+    /// Convenience: the prompt of the most recent exchange (for the panel "Last request" bar).
+    var lastRequest: String? { exchanges.last?.prompt }
+
+    init(projectName: String, projectPath: String? = nil, workingDirectory: String? = nil, started: Bool = false, groupId: UUID? = nil) {
         self.id = UUID()
         self.projectName = projectName
         self.projectPath = projectPath
@@ -37,19 +122,59 @@ struct TerminalSession: Identifiable {
         self.generation = 0
         self.hasBeenSelected = started // if started immediately (e.g. "+" button), mark as selected
         self.createdAt = Date()
+        self.exchanges = []
+        self.activityLine = nil
+        self.pendingChoices = []
+        self.pendingQuestion = nil
+        self.pendingPromptPreview = nil
+        self.groupId = groupId
     }
 
     /// Restore a session from persisted data
     init(persisted: PersistedSession) {
         self.id = persisted.id
         self.projectName = persisted.projectName
-        self.projectPath = persisted.projectPath
-        self.workingDirectory = persisted.workingDirectory
+        // Migrate sessions persisted by older builds where AppleScript's
+        // `missing value` leaked through as a literal path string.
+        let projectPath: String? = {
+            guard let p = persisted.projectPath, !p.isEmpty, p != "missing value" else { return nil }
+            return p
+        }()
+        self.projectPath = projectPath
+        // The project's containing directory (projectPath points at the
+        // .xcodeproj/.xcworkspace itself, so cd one level up).
+        let projectDir: String? = projectPath.flatMap { p in
+            let dir = (p as NSString).deletingLastPathComponent
+            return FileManager.default.fileExists(atPath: dir) ? dir : nil
+        }
+        // Fall back if the persisted directory is empty, no longer exists, or is
+        // "/" — a failed chdir leaves the shell in the app's own cwd (root),
+        // which OSC 7 then persisted; no real session lives at root.
+        var dir = persisted.workingDirectory
+        if dir.isEmpty || dir == "/" || !FileManager.default.fileExists(atPath: dir) {
+            dir = projectDir ?? NSHomeDirectory()
+        }
+        self.workingDirectory = dir
         self.hasStarted = false
         self.terminalStatus = .idle
         self.generation = 0
         self.hasBeenSelected = false
         self.createdAt = Date()
+        // Demote any in-flight summaries to .failed — we can't resume the API
+        // call across launches, and the terminal buffer that fed it is gone.
+        self.exchanges = persisted.exchanges.map { exchange in
+            var e = exchange
+            if e.summaryStatus == .generating {
+                e.summaryStatus = e.summary == nil ? .failed : .ready
+            }
+            return e
+        }
+        self.activityLine = nil
+        self.pendingChoices = []
+        self.pendingQuestion = nil
+        self.pendingPromptPreview = nil
+        self.pendingPromptText = persisted.pendingPromptText
+        self.groupId = persisted.groupId
     }
 }
 
@@ -59,4 +184,35 @@ struct PersistedSession: Codable {
     let projectName: String
     let projectPath: String?
     let workingDirectory: String
+    var exchanges: [TaskExchange] = []
+    /// Draft text the user was composing in Claude's input box at quit time.
+    /// Live status / choices / spinner aren't saved — they describe a dead claude process.
+    var pendingPromptText: String?
+    /// Group membership. nil for pre-grouping sessions; resolved on first load.
+    var groupId: UUID?
+
+    enum CodingKeys: String, CodingKey {
+        case id, projectName, projectPath, workingDirectory, exchanges, pendingPromptText, groupId
+    }
+
+    init(id: UUID, projectName: String, projectPath: String?, workingDirectory: String, exchanges: [TaskExchange], pendingPromptText: String?, groupId: UUID?) {
+        self.id = id
+        self.projectName = projectName
+        self.projectPath = projectPath
+        self.workingDirectory = workingDirectory
+        self.exchanges = exchanges
+        self.pendingPromptText = pendingPromptText
+        self.groupId = groupId
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.projectName = try c.decode(String.self, forKey: .projectName)
+        self.projectPath = try c.decodeIfPresent(String.self, forKey: .projectPath)
+        self.workingDirectory = try c.decode(String.self, forKey: .workingDirectory)
+        self.exchanges = (try? c.decode([TaskExchange].self, forKey: .exchanges)) ?? []
+        self.pendingPromptText = try? c.decodeIfPresent(String.self, forKey: .pendingPromptText)
+        self.groupId = try? c.decodeIfPresent(UUID.self, forKey: .groupId)
+    }
 }

--- a/Notchy/UsageMonitor.swift
+++ b/Notchy/UsageMonitor.swift
@@ -1,0 +1,404 @@
+import AppKit
+import OSLog
+import SwiftTerm
+
+private let usageLog = Logger(subsystem: "com.notchy.app", category: "UsageMonitor")
+
+/// A parsed slice of `/usage` output for one window (5-hour, weekly, weekly Opus, etc).
+struct UsageWindow: Identifiable, Equatable, Codable {
+    var id: String { label }
+    let label: String
+    let percent: Int
+    let resets: String?
+}
+
+/// A parsed `/usage` snapshot.
+struct UsageSnapshot: Equatable, Codable {
+    let fetchedAt: Date
+    let plan: String?
+    let windows: [UsageWindow]
+    /// Full raw text we scraped — kept so the UI can show something even if parsing misses fields.
+    let raw: String
+}
+
+/// Polls Claude Code's `/usage` command via a long-lived hidden `claude` PTY,
+/// then parses the rendered panel into a structured snapshot for the Conductor.
+///
+/// Long-lived (vs spawn-per-poll) because cold-starting `claude` takes 3–5s
+/// and is heavy. Once spawned, we just send `/usage`, wait, scrape, send ESC.
+@Observable
+@MainActor
+final class UsageMonitor {
+    static let shared = UsageMonitor()
+
+    private(set) var snapshot: UsageSnapshot?
+    private(set) var isRefreshing: Bool = false
+    private(set) var lastError: String?
+
+    private static let refreshInterval: TimeInterval = 300
+    /// Hard timeout for an in-flight refresh. If `refreshInProgress` has been
+    /// stuck longer than this (e.g. scrape closure short-circuited because the
+    /// hidden terminal got deallocated), force-clear it so subsequent calls
+    /// aren't permanently skipped.
+    private static let refreshStuckTimeout: TimeInterval = 30
+    /// Initial delay before the first scrape attempt — gives claude time to
+    /// render the /usage panel frame (tabs + "Loading usage data…" placeholder).
+    private static let initialScrapeDelay: TimeInterval = 1.5
+    /// Interval between subsequent re-scrape attempts while we wait for
+    /// "Loading usage data…" to be replaced by real percentages.
+    private static let pollInterval: TimeInterval = 0.5
+    /// Maximum total time to wait for the panel to populate before giving up.
+    private static let scrapeBudget: TimeInterval = 10.0
+    /// How long after spawn before claude has likely rendered something.
+    private static let warmupDelay: TimeInterval = 4.0
+    /// How long after accepting trust before claude's main prompt is usable.
+    private static let postTrustDelay: TimeInterval = 3.0
+    private static let snapshotKey = "usageSnapshot"
+
+    private enum BootstrapState {
+        case notStarted
+        case spawning
+        case acceptingTrust
+        case ready
+    }
+
+    private var terminal: HiddenTerminal?
+    private var refreshTimer: Timer?
+    private var bootstrapState: BootstrapState = .notStarted
+    /// Suppresses concurrent refreshes when one is already in flight.
+    private var refreshInProgress = false
+    /// Wall-clock time the in-flight refresh started — used to detect a stuck flag.
+    private var refreshStartedAt: Date?
+
+    private init() {
+        // Restore the last snapshot so the Conductor's usage header has data
+        // immediately on launch instead of being blank for the ~6s warmup.
+        if let data = UserDefaults.standard.data(forKey: Self.snapshotKey),
+           let restored = try? JSONDecoder().decode(UsageSnapshot.self, from: data) {
+            self.snapshot = restored
+        }
+    }
+
+    func start() {
+        guard bootstrapState == .notStarted else { return }
+        usageLog.info("start() — spawning hidden claude")
+        bootstrapState = .spawning
+        spawnTerminalIfNeeded()
+
+        // After warmup, accept the workspace-trust prompt (Enter selects the
+        // default "Yes, I trust" option). If claude is already past the trust
+        // prompt for some reason, Enter at the main input box is harmless.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.warmupDelay) { [weak self] in
+            guard let self, let term = self.terminal else { return }
+            let preTrust = term.scrapeBuffer()
+            usageLog.info("post-warmup scrape (first 300 chars): \(preTrust.prefix(300), privacy: .public)")
+            self.bootstrapState = .acceptingTrust
+            usageLog.info("sending Enter to accept trust prompt")
+            term.send(text: "\r")
+
+            // Give claude a moment to render its main prompt, then begin polling.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.postTrustDelay) { [weak self] in
+                guard let self else { return }
+                self.bootstrapState = .ready
+                usageLog.info("bootstrap complete — beginning /usage polling")
+                self.refreshNow()
+                self.refreshTimer = Timer.scheduledTimer(withTimeInterval: Self.refreshInterval, repeats: true) { [weak self] _ in
+                    Task { @MainActor in self?.refreshNow() }
+                }
+            }
+        }
+    }
+
+    /// Refresh only if no snapshot or the current snapshot is older than `maxAge`.
+    /// Called after each completed task so usage stays current without hammering /usage
+    /// when several sessions finish in quick succession.
+    func refreshIfStale(maxAge: TimeInterval) {
+        if let fetched = snapshot?.fetchedAt, Date().timeIntervalSince(fetched) < maxAge {
+            return
+        }
+        refreshNow()
+    }
+
+    func refreshNow() {
+        if refreshInProgress {
+            if let started = refreshStartedAt, Date().timeIntervalSince(started) > Self.refreshStuckTimeout {
+                usageLog.warning("refresh appeared stuck for >\(Self.refreshStuckTimeout, privacy: .public)s — clearing flag and retrying")
+                refreshInProgress = false
+                refreshStartedAt = nil
+                isRefreshing = false
+            } else {
+                usageLog.debug("refreshNow skipped — already in flight")
+                return
+            }
+        }
+        guard bootstrapState == .ready else {
+            usageLog.debug("refreshNow skipped — bootstrap not ready (state=\(String(describing: self.bootstrapState), privacy: .public))")
+            return
+        }
+        guard let term = terminal else {
+            usageLog.warning("refreshNow with nil terminal — respawning")
+            spawnTerminalIfNeeded()
+            return
+        }
+
+        // If claude exited (e.g. user/system killed it), the scrape buffer will
+        // show a zsh prompt. Detect and respawn instead of typing /usage into the shell.
+        let preCheck = term.scrapeBuffer()
+        if preCheck.contains("zsh:") || preCheck.range(of: #"% $"#, options: .regularExpression) != nil {
+            usageLog.warning("detected zsh prompt in buffer — claude has exited, respawning")
+            terminal = nil
+            bootstrapState = .notStarted
+            refreshTimer?.invalidate()
+            refreshTimer = nil
+            start()
+            return
+        }
+
+        refreshInProgress = true
+        refreshStartedAt = Date()
+        isRefreshing = true
+        usageLog.info("sending /usage")
+        term.send(text: "/usage\r")
+
+        let started = Date()
+        scrapeWhenReady(term: term, startedAt: started, delay: Self.initialScrapeDelay)
+    }
+
+    /// Resets in-flight tracking so the next refresh isn't suppressed. Called
+    /// from every exit path of `scrapeWhenReady`, including the weak-ref no-op.
+    private func finishRefresh() {
+        isRefreshing = false
+        refreshInProgress = false
+        refreshStartedAt = nil
+    }
+
+    /// Polls the /usage buffer until it actually contains percentage data
+    /// (claude renders "Loading usage data…" first and fills in numbers a
+    /// beat later). Falls back to whatever's there when the budget expires.
+    private func scrapeWhenReady(term: HiddenTerminal, startedAt: Date, delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak term] in
+            guard let self else { return }
+            guard let term else {
+                usageLog.warning("scrapeWhenReady: hidden terminal deallocated mid-refresh — clearing flag")
+                self.finishRefresh()
+                return
+            }
+            let raw = term.scrapeBuffer()
+            let elapsed = Date().timeIntervalSince(startedAt)
+            let elapsedStr = String(format: "%.1f", elapsed)
+            let hasUsageData = raw.range(of: #"\d+%\s+used"#, options: .regularExpression) != nil
+            let stillLoading = raw.contains("Loading usage data")
+
+            if !hasUsageData && stillLoading && elapsed < Self.scrapeBudget {
+                usageLog.debug("usage still loading at \(elapsedStr, privacy: .public)s, re-polling")
+                self.scrapeWhenReady(term: term, startedAt: startedAt, delay: Self.pollInterval)
+                return
+            }
+
+            let parsed = Self.parse(raw: raw)
+            usageLog.info("scraped /usage — plan=\(parsed.plan ?? "nil", privacy: .public) windows=\(parsed.windows.count) elapsed=\(elapsedStr, privacy: .public)s")
+            Self.appendDebugLog(raw: raw, parsed: parsed)
+            if !parsed.windows.isEmpty || parsed.plan != nil {
+                self.snapshot = parsed
+                if let data = try? JSONEncoder().encode(parsed) {
+                    UserDefaults.standard.set(data, forKey: Self.snapshotKey)
+                }
+                self.lastError = nil
+            } else if self.snapshot == nil {
+                self.lastError = "No /usage output parsed (claude may still be loading)."
+                usageLog.warning("no usage data parsed and no prior snapshot")
+            }
+            self.finishRefresh()
+            // Dismiss the /usage panel so it's not in the way on the next poll.
+            // Safe now because we know claude is past the trust prompt.
+            term.send(text: "\u{1B}")
+        }
+    }
+
+    /// Writes each scrape to `~/Library/Logs/Notchy/usage-raw.log` so we can
+    /// see what `/usage` actually renders and tune the parser against it.
+    private static func appendDebugLog(raw: String, parsed: UsageSnapshot) {
+        let fm = FileManager.default
+        guard let logsDir = fm.urls(for: .libraryDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("Logs/Notchy", isDirectory: true) else { return }
+        try? fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        let logURL = logsDir.appendingPathComponent("usage-raw.log")
+
+        let ts = ISO8601DateFormatter().string(from: Date())
+        var block = "\n===== /usage scrape @ \(ts) =====\n"
+        block += "parsed: plan=\(parsed.plan ?? "nil") windows=\(parsed.windows.count)\n"
+        for w in parsed.windows {
+            block += "  • \(w.label) — \(w.percent)% \(w.resets ?? "")\n"
+        }
+        block += "----- raw buffer -----\n"
+        block += raw
+        block += "\n----- end -----\n"
+
+        if let data = block.data(using: .utf8) {
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                defer { try? handle.close() }
+                try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+            } else {
+                try? data.write(to: logURL)
+            }
+        }
+    }
+
+    private func spawnTerminalIfNeeded() {
+        guard terminal == nil else { return }
+        usageLog.info("spawning HiddenTerminal")
+        terminal = HiddenTerminal()
+    }
+
+    // MARK: - Parsing
+
+    /// Pull plan/percentages/reset info out of `/usage` text. Loose by design —
+    /// the exact format isn't documented and may shift across Claude Code versions.
+    static func parse(raw: String) -> UsageSnapshot {
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
+
+        // Plan: look for a line that says "Plan", "Subscription", "Current plan", or
+        // mentions a tier ("Max", "Pro").
+        var plan: String?
+        for line in lines {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            guard !t.isEmpty else { continue }
+            let lower = t.lowercased()
+            if lower.contains("plan:") || lower.contains("subscription") || lower.contains("current plan") {
+                plan = t
+                break
+            }
+        }
+        if plan == nil {
+            for line in lines.prefix(20) {
+                let t = line.trimmingCharacters(in: .whitespaces)
+                let lower = t.lowercased()
+                if (lower.contains("max ") || lower.hasPrefix("max(") || lower.contains("pro plan") || lower.contains("pro ")) && t.count < 80 {
+                    plan = t
+                    break
+                }
+            }
+        }
+
+        // Windows: only lines that read "N% used" — the canonical usage-row format.
+        // This filters out footnote percentages like "70% of your usage was at >150k context".
+        var windows: [UsageWindow] = []
+        for (i, line) in lines.enumerated() {
+            guard let percent = percentUsed(in: line) else { continue }
+            let label = walkUpwardForLabel(at: i, in: lines)
+            let resets = nearbyReset(around: i, in: lines)
+            if !windows.contains(where: { $0.label == label && $0.percent == percent }) {
+                windows.append(UsageWindow(label: label, percent: percent, resets: resets))
+            }
+        }
+
+        return UsageSnapshot(fetchedAt: Date(), plan: plan, windows: windows, raw: raw)
+    }
+
+    /// Matches the canonical "N% used" cell that ends every real usage row.
+    private static func percentUsed(in line: String) -> Int? {
+        guard let range = line.range(of: #"(\d+)%\s+used"#, options: .regularExpression) else { return nil }
+        let digits = line[range].prefix(while: { $0.isNumber })
+        return Int(digits)
+    }
+
+    /// Walks upward from a percent line looking for the header line above it,
+    /// skipping blanks, bar-glyph rows, and decoration. Falls back to "Usage".
+    private static func walkUpwardForLabel(at index: Int, in lines: [String]) -> String {
+        var k = index - 1
+        while k >= 0 {
+            let t = lines[k].trimmingCharacters(in: .whitespaces)
+            if t.isEmpty { k -= 1; continue }
+            // Skip rows that are mostly progress-bar / box-drawing glyphs with no real text.
+            let letters = t.unicodeScalars.filter { CharacterSet.letters.contains($0) }.count
+            if letters < 3 { k -= 1; continue }
+            if percentUsed(in: t) != nil { k -= 1; continue }
+            return String(t.prefix(60))
+        }
+        return "Usage"
+    }
+
+    private static func nearbyReset(around index: Int, in lines: [String]) -> String? {
+        // The "Resets ..." line for a usage row is always on the line directly below.
+        for offset in 1...2 {
+            let i = index + offset
+            guard i < lines.count else { break }
+            let t = lines[i].trimmingCharacters(in: .whitespaces)
+            guard t.lowercased().hasPrefix("resets") else { continue }
+            let after = t.dropFirst("resets".count).trimmingCharacters(in: .whitespaces)
+            return after.isEmpty ? nil : "resets " + after.prefix(60)
+        }
+        return nil
+    }
+}
+
+// MARK: - Hidden terminal
+
+/// Owns a hidden `LocalProcessTerminalView` running `claude` so we can
+/// scrape `/usage` output without disturbing user-visible sessions.
+@MainActor
+private final class HiddenTerminal {
+    private let view: ProbeTerminalView
+    /// Holds the terminal in an offscreen window so it has a window context (some
+    /// AppKit interactions get cranky without one). Window is never displayed.
+    private let window: NSWindow
+
+    init() {
+        let frame = NSRect(x: 0, y: 0, width: 1000, height: 700)
+        view = ProbeTerminalView(frame: frame)
+        view.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+
+        window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: true
+        )
+        window.contentView = view
+        window.isReleasedWhenClosed = false
+        // Position offscreen and never show.
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        var env = ProcessInfo.processInfo.environment
+        env["TERM"] = "xterm-256color"
+        env["LANG"] = env["LANG"] ?? "en_US.UTF-8"
+        let envArray = env.map { "\($0.key)=\($0.value)" }
+
+        view.startProcess(
+            executable: shell,
+            args: ["--login"],
+            environment: envArray,
+            execName: "-" + (shell as NSString).lastPathComponent
+        )
+        // cd home first so we have a neutral cwd, then launch claude.
+        view.send(txt: "cd ~ && clear && claude\r")
+    }
+
+    func send(text: String) {
+        view.send(txt: text)
+    }
+
+    /// Reads the terminal buffer into plain text (one string per row).
+    func scrapeBuffer() -> String {
+        let terminal = view.getTerminal()
+        guard terminal.rows > 0 else { return "" }
+        var lines: [String] = []
+        for row in 0..<terminal.rows {
+            var line = ""
+            for col in 0..<terminal.cols {
+                let ch = terminal.getCharacter(col: col, row: row) ?? " "
+                line.append(ch == "\u{0}" ? " " : ch)
+            }
+            // Trim trailing spaces but keep leading indentation (preserves label/value alignment).
+            while let last = line.last, last == " " { line.removeLast() }
+            lines.append(line)
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+/// Minimal LocalProcessTerminalView subclass — no delegate / no extra UI; we
+/// only ever read the buffer, never display or interact with it from the UI.
+private final class ProbeTerminalView: LocalProcessTerminalView {}

--- a/Notchy/XcodeDetector.swift
+++ b/Notchy/XcodeDetector.swift
@@ -6,7 +6,11 @@ struct XcodeProject: Equatable {
     let path: String
     var directoryPath: String {
         if path.isEmpty { return NSHomeDirectory() }
-        return (path as NSString).deletingLastPathComponent
+        let dir = (path as NSString).deletingLastPathComponent
+        // A bogus path (e.g. AppleScript "missing value" leaking through) would
+        // make the terminal chdir fail silently and start in the app's cwd.
+        guard FileManager.default.fileExists(atPath: dir) else { return NSHomeDirectory() }
+        return dir
     }
 
     static func == (lhs: XcodeProject, rhs: XcodeProject) -> Bool {
@@ -52,6 +56,7 @@ class XcodeDetector {
             if (count of workspace documents) > 0 then
                 set activeDoc to front workspace document
                 set docPath to path of activeDoc
+                if docPath is missing value then set docPath to ""
                 set docName to name of activeDoc
                 return docName & "|||" & docPath
             end if
@@ -76,6 +81,7 @@ class XcodeDetector {
             repeat with doc in workspace documents
                 set docName to name of doc
                 set docPath to path of doc
+                if docPath is missing value then set docPath to ""
                 set output to output & docName & "|||" & docPath & ":::"
             end repeat
             return output
@@ -106,7 +112,10 @@ class XcodeDetector {
         let name = components[0]
             .replacingOccurrences(of: ".xcodeproj", with: "")
             .replacingOccurrences(of: ".xcworkspace", with: "")
-        let path = components[1]
+        // Older builds let AppleScript's `missing value` coerce into the string —
+        // and it's still possible if the script-side guard is bypassed.
+        var path = components[1]
+        if path == "missing value" { path = "" }
 
         return XcodeProject(name: name, path: path)
     }


### PR DESCRIPTION
## Summary
- Adds `MicrophoneActivityMonitor`, a CoreAudio-based check for whether the default input device is currently running (i.e. another app has the mic open).
- New "Mute sounds during calls" toggle in Settings → General. When enabled, `SessionStore.playSound` skips playback while the mic is in use, so Zoom/Meet/FaceTime participants don't hear Notchy's alert chimes.
- Defaults to off; disabled in the UI when "Enable sounds" is off.

Stacked on #15 — the base will resolve cleanly to main once that PR merges.

## Test plan
- [ ] Launch the app with "Enable sounds" on and "Mute sounds during calls" off — confirm task-completion sounds still play.
- [ ] Toggle "Mute sounds during calls" on, join a Zoom/Meet/FaceTime call, trigger a Claude task completion — confirm no sound plays.
- [ ] End the call and trigger another completion — confirm sound plays again.
- [ ] Disable "Enable sounds" — confirm the mute toggle greys out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)